### PR TITLE
MWPW-150688 Add .html extension to sitemap

### DIFF
--- a/helix-sitemap.yaml
+++ b/helix-sitemap.yaml
@@ -5,6 +5,7 @@ sitemaps:
     origin: https://business.adobe.com
     lastmod: YYYY-MM-DD
     default: en-US
+    extension: .html
     languages:
       us:
         source: /query-index.json


### PR DESCRIPTION
* Add `.html` extension to sitemap based on new EDS functionality: https://www.aem.live/developer/sitemap#adding-an-extension-to-all-locations-in-the-sitemap

Resolves: [MWPW-150688](https://jira.corp.adobe.com/browse/MWPW-150688)

