### PR TITLE
Consume stage again

### DIFF
--- a/head.html
+++ b/head.html
@@ -4,7 +4,7 @@
   const libs = (() => {
     const { hostname, search } = window.location;
     if (!['.aem.', '.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '/libs';
-    const branch = new URLSearchParams(search).get('milolibs') || 'hlx5-upgrade';
+    const branch = new URLSearchParams(search).get('milolibs') || 'main';
     if (branch === 'local') return 'http://localhost:6456/libs';
     return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
   })();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -158,7 +158,7 @@ const loadStyle = (path) => {
 export function setLibs(location) {
   const { hostname, search } = location;
   if (!['.aem.', '.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '/libs';
-  const branch = new URLSearchParams(search).get('milolibs') || 'hlx5-upgrade';
+  const branch = new URLSearchParams(search).get('milolibs') || 'main';
   if (branch === 'local') return 'http://localhost:6456/libs';
   return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
 }

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -5,7 +5,7 @@ describe('Libs', () => {
   const tests = [
     ['https://business.adobe.com', '/libs'],
     ['https://business.adobe.com?milolibs=foo', '/libs'],
-    ['https://business.stage.adobe.com', 'https://hlx5-upgrade--milo--adobecom.aem.live/libs'],
+    ['https://business.stage.adobe.com', 'https://main--milo--adobecom.aem.live/libs'],
     ['https://business.stage.adobe.com?milolibs=foo', 'https://foo--milo--adobecom.aem.live/libs'],
     ['https://business.stage.adobe.com?milolibs=awesome--milo--forkedowner', 'https://awesome--milo--forkedowner.aem.live/libs'],
     ['https://main--da-bacom--adobecom.aem.page/', 'https://main--milo--adobecom.aem.live/libs'],
@@ -31,6 +31,6 @@ describe('Libs', () => {
   });
 
   it('Sets LIBS', () => {
-    expect(LIBS).to.equal('https://hlx5-upgrade--milo--adobecom.aem.live/libs');
+    expect(LIBS).to.equal('https://main--milo--adobecom.aem.live/libs');
   });
 });


### PR DESCRIPTION
With https://github.com/adobecom/milo/pull/3187 the milo hlx5 branch got merged and we can consume stage again.

**Test URLs:**
- Before: https://main--da-bacom--adobecom.hlx.live/?martech=off
- After: https://consume-stage--da-bacom--adobecom.hlx.live/?martech=off
