### PR TITLE
[MWPW-162868]: Temp fix for extra <p> tag in <li>

### DIFF
--- a/blocks/tree-view/tree-view.js
+++ b/blocks/tree-view/tree-view.js
@@ -109,6 +109,16 @@ const init = async (el) => {
   const topList = el.querySelector('ul');
 
   if (!topList) return;
+  // TODO: Remove after fix from Helix5
+  const listItems = topList.querySelectorAll('li');
+  [...listItems].forEach((liEl) => {
+    const paragraph = liEl.querySelector('p');
+    if (paragraph) {
+      // Moving the content of the <p> into the <li> directly
+      liEl.innerHTML = paragraph.innerHTML + liEl.innerHTML.replace(paragraph.outerHTML, '');
+    }
+  });
+  // END TODO: Remove after fix from Helix5
 
   const { createTag } = await import(`${LIBS}/utils/utils.js`);
   const subLists = topList.querySelectorAll('ul');


### PR DESCRIPTION
- Temporary fix to handle the extra `<p>` generated in HTML from Helix

Resolves: [MWPW-162868](https://jira.corp.adobe.com/browse/MWPW-162868)

Test URLs:

Before: https://main--da-bacom--adobecom.hlx.page/docs/library/blocks/tree-view?martech=off
After: https://mwpw-162868--da-bacom--adobecom.hlx.page/docs/library/blocks/tree-view?martech=off