### PR TITLE
MWPW-177491 Use stage milo libs link on stage

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -181,7 +181,7 @@ export function setLibs(location) {
   if (!['.aem.', '.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '/libs';
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
   if (branch === 'local') return 'http://localhost:6456/libs';
-  if (branch === 'main' && hostname === 'business.stage.adobe.com') return '/libs';
+  if (branch === 'main' && hostname.includes('.stage.')) return '/libs';
   return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -181,6 +181,7 @@ export function setLibs(location) {
   if (!['.aem.', '.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return '/libs';
   const branch = new URLSearchParams(search).get('milolibs') || 'main';
   if (branch === 'local') return 'http://localhost:6456/libs';
+  if (branch === 'main' && hostname === 'business.stage.adobe.com') return '/libs';
   return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
 }
 

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -6,7 +6,7 @@ describe('Libs', () => {
   const tests = [
     ['https://business.adobe.com', '/libs'],
     ['https://business.adobe.com?milolibs=foo', '/libs'],
-    ['https://business.stage.adobe.com', 'https://main--milo--adobecom.aem.live/libs'],
+    ['https://business.stage.adobe.com', '/libs'],
     ['https://business.stage.adobe.com?milolibs=foo', 'https://foo--milo--adobecom.aem.live/libs'],
     ['https://business.stage.adobe.com?milolibs=awesome--milo--forkedowner', 'https://awesome--milo--forkedowner.aem.live/libs'],
     ['https://main--da-bacom--adobecom.aem.page/', 'https://main--milo--adobecom.aem.live/libs'],


### PR DESCRIPTION
* When on business.stage.adobe.com, milo libs should come from the stage link, not the aem.live link
* The only exception is when using the query param `?milolibs=`, which will pull from aem.live still.
* All other environments stay the same.

Resolves: [MWPW-177491](https://jira.corp.adobe.com/browse/MWPW-177491)

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://stage-milo-libs--da-bacom--adobecom.aem.live/?martech=off
