### PR TITLE
MWPW-168315 Config key defining mapping from locale to captions language for adobetv

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -142,6 +142,7 @@ const CONFIG = {
     version: '1.0',
     onDemand: false,
   },
+  atvCaptionsKey: 'bacom',
 };
 
 const eagerLoad = (img) => {


### PR DESCRIPTION
As part of support added in milo to autoset AdobeTV captions based on locale a configuration key needs to be set.

Refer Milo PR - https://github.com/adobecom/milo/pull/4674

`/pt/drafts/mkhare/168315/fall-back?milolibs=stage`

Resolves: [MWPW-168315](https://jira.corp.adobe.com/browse/MWPW-168315)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://mwpw-168315--da-bacom--adobecom.aem.live/?martech=off
