### PR TITLE
MWPW-175672: Caas tags page gen

### DIFF
--- a/test/tools/caas-tag-selector/caas-tag-selector.test.js
+++ b/test/tools/caas-tag-selector/caas-tag-selector.test.js
@@ -1,0 +1,134 @@
+import { readFile } from '@web/test-runner-commands';
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+
+describe('Page Generator CaaS Tag Selector Fetching Data', () => {
+  before(async () => {
+    document.body.innerHTML = await readFile({ path: './mocks/index.html' });
+    // Stub fetch to avoid actual network requests
+    sinon.stub(window, 'fetch').callsFake((url) => {
+      // Return mock responses for expected URLs
+      if (url.includes('da.live/config/')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            data: [
+              { key: 'aem.repositoryId', value: 'test-aem-repo.com' },
+              { key: 'aem.tags.namespaces', value: 'namespace1, namespace2' },
+            ],
+          }),
+        });
+      }
+
+      if (url.includes('content/cq:tags')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            'test-tag': {
+              'jcr:primaryType': 'cq:Tag',
+              'jcr:title': 'caas:content-type',
+            },
+          }),
+        });
+      }
+
+      // Default mock response for any other URLs
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('{}'),
+      });
+    });
+  });
+
+  it('Has the body without an intialized component', () => {
+    expect(document.querySelector('body')).to.not.be.null;
+    expect(document.querySelector('pg-caas-tag-selector')).to.be.null;
+  });
+
+  it('Renders the component, making the correct fetch requests', () => {
+    const tagSelector = document.createElement('pg-caas-tag-selector');
+    document.body.append(tagSelector);
+    const renderedTagSelector = document.querySelector('pg-caas-tag-selector');
+    expect(renderedTagSelector).to.not.be.null;
+  });
+
+  it('Makes the correct fetch requests when rendering', () => {
+    // Get the existing fetch stub to track calls
+    const fetchStub = window.fetch;
+
+    // Create the component
+    const tagSelector = document.createElement('pg-caas-tag-selector');
+    document.body.append(tagSelector);
+
+    // Wait a bit for the component to initialize and make fetch calls
+    setTimeout(() => {
+      // Verify that fetch was called
+      expect(fetchStub.called).to.be.true;
+
+      // Get all the URLs that were fetched
+      const fetchCalls = fetchStub.getCalls();
+      const fetchUrls = fetchCalls.map((call) => call.args[0]);
+
+      // Check that the component made calls to expected endpoints
+      expect(fetchUrls.some((url) => url.includes('da.live/config/'))).to.be.true;
+      expect(fetchUrls.some((url) => url.includes('content/cq:tags'))).to.be.true;
+    }, 100);
+  });
+
+  it('Renders with the correct options in the select inputs', () => {
+    // Create the component
+    const tagSelector = document.createElement('pg-caas-tag-selector');
+    document.body.append(tagSelector);
+
+    // Wait for the component to render
+    setTimeout(() => {
+      // Check that the component has a shadow root
+      expect(tagSelector.shadowRoot).to.exist;
+
+      // Check the main container structure
+      const tagSelectorGroup = tagSelector.shadowRoot.querySelector('.tag-selector-group');
+      expect(tagSelectorGroup).to.exist;
+
+      // Check content type select structure
+      const contentTypeSelect = tagSelector.shadowRoot.querySelector('#caas-content-type');
+      expect(contentTypeSelect).to.exist;
+      expect(contentTypeSelect.name).to.equal('caas-content-type');
+      expect(contentTypeSelect.id).to.equal('caas-content-type');
+
+      // Check content type options
+      const contentTypeOptions = contentTypeSelect.querySelectorAll('option');
+      expect(contentTypeOptions).to.have.length(1); // Should have default "--Select--" option
+      expect(contentTypeOptions[0].value).to.equal('');
+      expect(contentTypeOptions[0].textContent).to.equal('--Select--');
+
+      // Check primary product select structure
+      const productSelect = tagSelector.shadowRoot.querySelector('#caas-primary-product');
+      expect(productSelect).to.exist;
+      expect(productSelect.name).to.equal('caas-primary-product');
+      expect(productSelect.id).to.equal('caas-primary-product');
+
+      // Check primary product options
+      const productOptions = productSelect.querySelectorAll('option');
+      expect(productOptions).to.have.length(1); // Should have default "--Select--" option
+      expect(productOptions[0].value).to.equal('');
+      expect(productOptions[0].textContent).to.equal('--Select--');
+
+      // Check labels are present and correct
+      const labels = tagSelector.shadowRoot.querySelectorAll('label');
+      expect(labels).to.have.length(2);
+
+      const contentTypeLabel = tagSelector.shadowRoot.querySelector('label[for="caas-content-type"]');
+      expect(contentTypeLabel).to.exist;
+      expect(contentTypeLabel.textContent).to.include('CaaS Content Type');
+
+      const productLabel = tagSelector.shadowRoot.querySelector('label[for="caas-primary-product"]');
+      expect(productLabel).to.exist;
+      expect(productLabel.textContent).to.include('CaaS Primary Product');
+
+      // Check that labels are properly associated with their selects
+      expect(contentTypeLabel.getAttribute('for')).to.equal(contentTypeSelect.id);
+      expect(productLabel.getAttribute('for')).to.equal(productSelect.id);
+    }, 100);
+  });
+});

--- a/test/tools/caas-tag-selector/caas-tag-selector.test.js
+++ b/test/tools/caas-tag-selector/caas-tag-selector.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 describe('Page Generator CaaS Tag Selector Fetching Data', () => {
   before(async () => {
-    document.body.innerHTML = await readFile({ path: './mocks/index.html' });
+    document.body.innerHTML = await readFile({ path: '../../../tools/caas-tag-selector/index.html' });
     // Stub fetch to avoid actual network requests
     sinon.stub(window, 'fetch').callsFake((url) => {
       // Return mock responses for expected URLs
@@ -41,12 +41,7 @@ describe('Page Generator CaaS Tag Selector Fetching Data', () => {
     });
   });
 
-  it('Has the body without an intialized component', () => {
-    expect(document.querySelector('body')).to.not.be.null;
-    expect(document.querySelector('pg-caas-tag-selector')).to.be.null;
-  });
-
-  it('Renders the component, making the correct fetch requests', () => {
+  it('Renders the component', () => {
     const tagSelector = document.createElement('pg-caas-tag-selector');
     document.body.append(tagSelector);
     const renderedTagSelector = document.querySelector('pg-caas-tag-selector');

--- a/test/tools/caas-tag-selector/mocks/index.html
+++ b/test/tools/caas-tag-selector/mocks/index.html
@@ -15,8 +15,5 @@
     </style>
   </head>
   <body>
-    <main>
-      <pg-caas-tag-selector></pg-caas-tag-selector>
-    </main>
   </body>
 </html>

--- a/tools/caas-tag-selector/index.html
+++ b/tools/caas-tag-selector/index.html
@@ -15,6 +15,8 @@
     </style>
   </head>
   <body>
-    <main></main>
+    <main>
+      <da-tag-selector></da-tag-selector>
+    </main>
   </body>
 </html>

--- a/tools/caas-tag-selector/index.html
+++ b/tools/caas-tag-selector/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>DA App SDK Sample</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="icon" href="data:,">
+    <!-- Import DA App SDK -->
+    <script src="https://da.live/nx/utils/sdk.js" type="module"></script>
+    <!-- Project App Logic -->
+    <script src="/tools/caas-tag-selector/tag-selector.js" type="module"></script>
+    <style>
+      body {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main></main>
+  </body>
+</html>

--- a/tools/caas-tag-selector/tag-selector.css
+++ b/tools/caas-tag-selector/tag-selector.css
@@ -1,0 +1,5 @@
+.tag-selector-group {
+  margin: 20px;
+  display: flex;
+  flex-direction: column;
+}

--- a/tools/caas-tag-selector/tag-selector.js
+++ b/tools/caas-tag-selector/tag-selector.js
@@ -3,7 +3,14 @@ import 'https://da.live/nx/public/sl/components.js';
 import { LitElement, html } from 'https://da.live/nx/deps/lit/lit-core.min.js';
 import getStyle from 'https://da.live/nx/utils/styles.js';
 import DA_SDK from 'https://da.live/nx/utils/sdk.js';
-import { getTags, getAemRepo, getRootTags } from '../tags/tag-utils.js';
+import {
+  getTags,
+  getAemRepo,
+  getRootTags,
+  jcrTitle,
+  caasContentType,
+  caasProducts,
+} from '../tags/tag-utils.js';
 
 const style = await getStyle(import.meta.url);
 const { context, token } = await DA_SDK.catch(() => null);
@@ -67,8 +74,10 @@ class PageGeneratorCaaSTagSelector extends LitElement {
       const rootCollections = await processRootTags(options);
       currentCollection = await getTagCollection(rootCollections, collectionName, options);
     }
-    const caasContentTypeCollection = currentCollection.filter((tag) => tag.details['jcr:title'].includes('caas:content-type'));
-    const caasPrimaryProductCollection = currentCollection.filter((tag) => tag.details['jcr:title'].includes('caas:products'));
+    const caasContentTypeCollection = currentCollection
+      .filter((tag) => tag.details[jcrTitle].includes(caasContentType));
+    const caasPrimaryProductCollection = currentCollection
+      .filter((tag) => tag.details[jcrTitle].includes(caasProducts));
     this._contentTypes = caasContentTypeCollection;
     this._caasPPN = caasPrimaryProductCollection;
   }

--- a/tools/caas-tag-selector/tag-selector.js
+++ b/tools/caas-tag-selector/tag-selector.js
@@ -1,8 +1,34 @@
 /* eslint-disable no-underscore-dangle, import/no-unresolved */
 import { LitElement, html, nothing } from 'https://da.live/nx/deps/lit/lit-core.min.js';
 import getStyle from 'https://da.live/nx/utils/styles.js';
+import DA_SDK from 'https://da.live/nx/utils/sdk.js';
+import { getTags, getAemRepo, getRootTags } from '../tags/tag-utils.js';
 
 const style = await getStyle(import.meta.url);
+const UI_TAG_PATH = '/ui#/aem/aem/tags';
+
+const { context, actions, token } = await DA_SDK.catch(() => null);
+
+const opts = { headers: { Authorization: `Bearer ${token}` } };
+const aemConfig = await getAemRepo(context, opts).catch(() => null);
+if (!aemConfig || !aemConfig.aemRepo) {
+  console.log('error');
+  // return;
+}
+
+const namespaces = aemConfig?.namespaces.split(',').map((namespace) => namespace.trim()) || [];
+const rootTags = await getRootTags(namespaces, aemConfig, opts);
+
+if (!rootTags || rootTags.length === 0) {
+  console.log('error');
+  // return;
+}
+
+for (const tag of rootTags) {
+  console.log(tag, rootTags);
+  const tagList = await getTags(tag.path, opts);
+  console.log(tagList);
+}
 
 class DaTagSelector extends LitElement {
   static properties = {
@@ -19,7 +45,7 @@ class DaTagSelector extends LitElement {
   }
 
   render() {
-    if (this._tags.length === 0) return nothing;
+    // if (this._tags.length === 0) return nothing;
     return html`
       <div class="tag-selector-group">
         <label for"caas-content-type">CaaS Content Type</label>

--- a/tools/caas-tag-selector/tag-selector.js
+++ b/tools/caas-tag-selector/tag-selector.js
@@ -7,15 +7,15 @@ import {
   getTags,
   getAemRepo,
   getRootTags,
-  jcrTitle,
-  caasContentType,
-  caasProducts,
 } from '../tags/tag-utils.js';
 
 const style = await getStyle(import.meta.url);
 const { context, token } = await DA_SDK.catch(() => null);
 const options = { headers: { Authorization: `Bearer ${token}` } };
 const collectionName = 'dx-tags/dx-caas';
+const jcrTitle = 'jcr:title';
+const caasContentType = 'caas:content-type';
+const caasProducts = 'caas:products';
 
 async function processRootTags(opts) {
   const aemConfig = await getAemRepo(context, opts).catch(() => null);
@@ -27,6 +27,7 @@ async function processRootTags(opts) {
   if (!aemConfig || !aemConfig.aemRepo) {
     const repoError = 'Error in retrieving AemRepo';
     errorEvent(repoError);
+    return [];
   }
 
   const namespaces = aemConfig?.namespaces.split(',').map((namespace) => namespace.trim()) || [];
@@ -68,7 +69,7 @@ class PageGeneratorCaaSTagSelector extends LitElement {
 
   async setCollections() {
     let currentCollection;
-    if (this.propCollection && this?.propCollection?.length > 0) {
+    if (this?.propCollection?.length > 0) {
       currentCollection = this.propCollection;
     } else {
       const rootCollections = await processRootTags(options);

--- a/tools/caas-tag-selector/tag-selector.js
+++ b/tools/caas-tag-selector/tag-selector.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-underscore-dangle, import/no-unresolved */
+import { LitElement, html, nothing } from 'https://da.live/nx/deps/lit/lit-core.min.js';
+import getStyle from 'https://da.live/nx/utils/styles.js';
+
+const style = await getStyle(import.meta.url);
+
+class DaTagSelector extends LitElement {
+  static properties = {
+  };
+
+  constructor() {
+    super();
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.shadowRoot.adoptedStyleSheets = [style];
+    this.addEventListener('blur', this.handleBlur, true);
+  }
+
+  render() {
+    if (this._tags.length === 0) return nothing;
+    return html`
+      <div class="tag-selector-group">
+        <label for"caas-content-type">CaaS Content Type</label>
+        <select name="caas-content-type" id="caas-content-type">
+          <option value=''>--Select--</option>
+          ${this._contentTypes ? this._contentTypes.map((val) => html`<option value=${val}>${val}</option>`) : nothing}
+        </select>
+        <label for"caas-primary-product">CaaS Primary Product</label>
+        <select name="caas-primary-product" id="caas-primary-product">
+          <option value=''>--Select--</option>
+          ${this._caasPPN ? this._caasPPN.map((val) => html`<option value=${val}>${val}</option>`) : nothing}
+        </select>
+        <label for"primary-product-name">Primary Product Name</label>
+        <select name="primary-product-name" id="primary-product-name">
+          <option value=''>--Select--</option>
+          ${this._ppn ? this._ppn.map((val) => html`<option value=${val}>${val}</option>`) : nothing}
+        </select>
+      </div>
+    `;
+  }
+}
+
+customElements.define('da-tag-selector', DaTagSelector);

--- a/tools/tags/tag-utils.js
+++ b/tools/tags/tag-utils.js
@@ -1,0 +1,68 @@
+/* eslint-disable import/no-unresolved */
+import { DA_ORIGIN } from 'https://da.live/nx/public/utils/constants.js';
+
+export const tagPathConfig = {
+  root: '/content/cq:tags',
+  ext: '.1.json',
+};
+
+export function setTagPathConfig({ root, ext }) {
+  tagPathConfig.root = root;
+  tagPathConfig.ext = ext;
+}
+
+export async function getAemRepo(project, opts) {
+  const configUrl = `${DA_ORIGIN}/config/${project.org}/${project.repo}`;
+  const resp = await fetch(configUrl, opts);
+  if (!resp.ok) return null;
+  const json = await resp.json();
+  const data = Array.isArray(json.data?.data) ? json.data.data : json.data;
+  const aemRepo = data?.find((entry) => entry.key === 'aem.repositoryId')?.value;
+  const namespaces = data?.find((entry) => entry.key === 'aem.tags.namespaces')?.value;
+  return { aemRepo, namespaces };
+}
+
+export async function getTags(path, opts) {
+  const activeTag = path.split('cq:tags').pop().replace('.1.json', '').slice(1);
+  const resp = await fetch(path, opts);
+  if (!resp.ok) return null;
+  const json = await resp.json();
+  const tags = Object.keys(json).reduce((acc, key) => {
+    if (json[key]['jcr:primaryType'] === 'cq:Tag') {
+      acc.push({
+        path: `${path.replace(tagPathConfig.ext, '')}/${key}${tagPathConfig.ext}`,
+        activeTag,
+        name: key,
+        title: json[key]['jcr:title'] || key,
+        details: json[key],
+      });
+    }
+    return acc;
+  }, []);
+
+  return tags;
+}
+
+export const getRootTags = async (namespaces, aemConfig, opts) => {
+  const createTagUrl = (namespace = '') => `https://${aemConfig.aemRepo}${tagPathConfig.root}${namespace ? `/${namespace}` : ''}${tagPathConfig.ext}`;
+
+  if (namespaces.length === 0) {
+    return getTags(createTagUrl(), opts).catch(() => null);
+  }
+
+  if (namespaces.length === 1) {
+    const namespace = namespaces[0].toLowerCase().replaceAll(' ', '-');
+    return getTags(createTagUrl(namespace), opts).catch(() => null);
+  }
+
+  return namespaces.map((title) => {
+    const namespace = title.toLowerCase().replaceAll(' ', '-');
+    return {
+      path: createTagUrl(namespace),
+      name: namespace,
+      title,
+      activeTag: '',
+      details: {},
+    };
+  });
+};

--- a/tools/tags/tag-utils.js
+++ b/tools/tags/tag-utils.js
@@ -6,6 +6,10 @@ export const tagPathConfig = {
   ext: '.1.json',
 };
 
+export const jcrTitle = 'jcr:title';
+export const caasContentType = 'caas:content-type';
+export const caasProducts = 'caas:products';
+
 export function setTagPathConfig({ root, ext }) {
   tagPathConfig.root = root;
   tagPathConfig.ext = ext;

--- a/tools/tags/tag-utils.js
+++ b/tools/tags/tag-utils.js
@@ -6,10 +6,6 @@ export const tagPathConfig = {
   ext: '.1.json',
 };
 
-export const jcrTitle = 'jcr:title';
-export const caasContentType = 'caas:content-type';
-export const caasProducts = 'caas:products';
-
 export function setTagPathConfig({ root, ext }) {
   tagPathConfig.root = root;
   tagPathConfig.ext = ext;

--- a/tools/tags/tags.js
+++ b/tools/tags/tags.js
@@ -1,67 +1,9 @@
 /* eslint-disable import/no-unresolved */
 import DA_SDK from 'https://da.live/nx/utils/sdk.js';
-import { DA_ORIGIN } from 'https://da.live/nx/public/utils/constants.js';
+import { getAemRepo, getTags, getRootTags } from './tag-utils.js';
 import './tag-browser.js';
 
-const ROOT_TAG_PATH = '/content/cq:tags';
 const UI_TAG_PATH = '/ui#/aem/aem/tags';
-const TAG_EXT = '.1.json';
-
-async function getAemRepo(project, opts) {
-  const configUrl = `${DA_ORIGIN}/config/${project.org}/${project.repo}`;
-  const resp = await fetch(configUrl, opts);
-  if (!resp.ok) return null;
-  const json = await resp.json();
-  const data = Array.isArray(json.data?.data) ? json.data.data : json.data;
-  const aemRepo = data?.find((entry) => entry.key === 'aem.repositoryId')?.value;
-  const namespaces = data?.find((entry) => entry.key === 'aem.tags.namespaces')?.value;
-  return { aemRepo, namespaces };
-}
-
-async function getTags(path, opts) {
-  const activeTag = path.split('cq:tags').pop().replace('.1.json', '').slice(1);
-  const resp = await fetch(path, opts);
-  if (!resp.ok) return null;
-  const json = await resp.json();
-  const tags = Object.keys(json).reduce((acc, key) => {
-    if (json[key]['jcr:primaryType'] === 'cq:Tag') {
-      acc.push({
-        path: `${path.replace(TAG_EXT, '')}/${key}${TAG_EXT}`,
-        activeTag,
-        name: key,
-        title: json[key]['jcr:title'] || key,
-        details: json[key],
-      });
-    }
-    return acc;
-  }, []);
-
-  return tags;
-}
-
-const getRootTags = async (namespaces, aemConfig, opts) => {
-  const createTagUrl = (namespace = '') => `https://${aemConfig.aemRepo}${ROOT_TAG_PATH}${namespace ? `/${namespace}` : ''}${TAG_EXT}`;
-
-  if (namespaces.length === 0) {
-    return getTags(createTagUrl(), opts).catch(() => null);
-  }
-
-  if (namespaces.length === 1) {
-    const namespace = namespaces[0].toLowerCase().replaceAll(' ', '-');
-    return getTags(createTagUrl(namespace), opts).catch(() => null);
-  }
-
-  return namespaces.map((title) => {
-    const namespace = title.toLowerCase().replaceAll(' ', '-');
-    return {
-      path: createTagUrl(namespace),
-      name: namespace,
-      title,
-      activeTag: '',
-      details: {},
-    };
-  });
-};
 
 function showError(message, link = null) {
   const mainElement = document.body.querySelector('main');


### PR DESCRIPTION
* Adds a small component to render tags pulled from Aem tags 

Resolves: [MWPW-175672](https://jira.corp.adobe.com/browse/MWPW-175672)

Tool page: https://da.live/app/adobecom/da-bacom/tools/caas-tag-selector/index?ref=caas-tags-page-gen

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://caas-tags-page-gen--da-bacom--adobecom.aem.live/?martech=off
