### PR TITLE
MWPW-183761 Enable sidekick publish confirmation dialog

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -6,6 +6,10 @@
   "trustedHosts": ["milo.adobe.com"],
   "plugins": [
     {
+      "id": "publish",
+      "confirm": true
+    },
+    {
       "id": "tools",
       "title": "Tools",
       "isContainer": true


### PR DESCRIPTION
* Enable sidekick publish confirmation dialog

Resolves: [MWPW-183761](https://jira.corp.adobe.com/browse/MWPW-183761)

**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://methomas-publish-confirm--da-bacom--adobecom.aem.live/?martech=off

Note: This is not testable before release

<img width="475" height="392" alt="Screenshot 2025-11-12 at 10 37 06 AM" src="https://github.com/user-attachments/assets/0e8ebcc7-b389-4d0e-a06d-6e23a7cb710c" />
