### PR TITLE
Ping sitemap bug

### DIFF
--- a/head.html
+++ b/head.html
@@ -71,7 +71,8 @@
       
       const urlElements = xmlDoc.querySelectorAll('url');
       let currentUrlElement = null;
-      const currentPageUrl = pathname !== '/' ? `${sitemapOrigin}${pathname}.html` : `${sitemapOrigin}/`;
+      const correctedPath = pathname.includes('html') ? pathname : `${pathname}.html`
+      const currentPageUrl = pathname !== '/' ? `${sitemapOrigin}${correctedPath}` : `${sitemapOrigin}/`;
 
       for (const urlElement of urlElements) {
         const loc = urlElement.querySelector('loc')?.textContent;


### PR DESCRIPTION
* Ensuring that the pathname does not get html appended twice

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://html-bots-bug-fix--da-bacom--adobecom.aem.live/?martech=off
