### PR TITLE
MWPW-185847: Adding a config object for lingo logging

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -149,6 +149,7 @@ const CONFIG = {
     la: ['bo', 'cr', 'do', 'ec', 'gt', 'pa', 'pr', 'py', 'sv', 'uy', 've'],
     mena_en: ['bh', 'dz', 'iq', 'ir', 'jo', 'lb', 'ly', 'om', 'ps', 'sy', 'tn', 'ye'],
   },
+  lingoProjectSuccessLogging: 'on',
 };
 
 const eagerLoad = (img) => {


### PR DESCRIPTION
* Adds a config object that allows Milo to know to send a lana log when the region nav model is opened. 

https://jira.corp.adobe.com/browse/MWPW-185847

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://lingo-logging-config--da-bacom--adobecom.aem.live/?martech=off
