### PR TITLE
MWPW-185960 Remove additional regex

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -127,7 +127,6 @@ const CONFIG = {
   ],
   htmlExclude: [
     /business\.adobe\.com\/(\w\w(_\w\w)?\/)?blog(\/.*)?/,
-    /(\w\w(_\w\w)?\/)?blog(\/.*)?/,
   ],
   useDotHtml: true,
   dynamicNavKey: 'bacom',


### PR DESCRIPTION
* Removes additional regex added to fix a CSO caused by decorate link changes from milo

Resolves: [MWPW-185960](https://jira.corp.adobe.com/browse/MWPW-MWPW-185960)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://remove-additional-regex--da-bacom--adobecom.aem.live/?martech=off
