### PR TITLE
MWPW-186054: Adds georouting metadata to 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
     <title>404</title>
     <meta name="template" content="404"/>
     <meta name="404" content="local" />
+    <meta name="georouting" content="off">
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <script type="module">
       import { applyRedirects } from '/scripts/redirects.js';


### PR DESCRIPTION
* Adds metatadata to disable the georouting popup from appearing on 404s

Resolves: [MWPW-186054](https://jira.corp.adobe.com/browse/MWPW-186054)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://404-no-georouting--da-bacom--adobecom.aem.live/?martech=off

## Testing:
https://404-no-georouting--da-bacom--adobecom.aem.live/fr/nope
