### PR TITLE
MWPW-189261: Add Qatar to the mena_en region mapping created for MEP

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -147,7 +147,7 @@ const CONFIG = {
   mepLingoCountryToRegion: {
     africa: ['ke', 'mu', 'ng', 'za'],
     la: ['bo', 'cr', 'do', 'ec', 'gt', 'pa', 'pr', 'py', 'sv', 'uy', 've', 'ar', 'co', 'cl', 'mx', 'pe'],
-    mena_en: ['bh', 'dz', 'iq', 'ir', 'jo', 'lb', 'ly', 'om', 'ps', 'sy', 'tn', 'ye'],
+    mena_en: ['bh', 'dz', 'iq', 'ir', 'jo', 'lb', 'ly', 'om', 'ps', 'qa', 'sy', 'tn', 'ye'],
   },
   lingoProjectSuccessLogging: 'on',
 };


### PR DESCRIPTION
Add Qatar (qa) to the mena_en region mapping created for MEP.

To validate, pass in akamaiLocale=qa and test if mep-lingo pulls content from the /mena_en/ path.

Resolves: [MWPW-189261](https://jira.corp.adobe.com/browse/MWPW-189261)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.page/drafts/sukamat/lingo/mep-lingo-test?akamaiLocale=qa&martech=off
- After: https://mwpw-189261--da-bacom--adobecom.aem.page/drafts/sukamat/lingo/mep-lingo-test?akamaiLocale=qa&martech=off
