### PR TITLE
Add progressive profiling test automation

### DIFF
--- a/nala/blocks/progressive-profiling/README.md
+++ b/nala/blocks/progressive-profiling/README.md
@@ -1,0 +1,118 @@
+# Progressive Profiling Nala Tests
+
+This suite lives in:
+
+- [progressive-profiling.spec.js](/Users/xiasun/Documents/Workspace/da-bacom/nala/blocks/progressive-profiling/progressive-profiling.spec.js)
+- [progressive-profiling.test.js](/Users/xiasun/Documents/Workspace/da-bacom/nala/blocks/progressive-profiling/progressive-profiling.test.js)
+- [progressive-profiling.page.js](/Users/xiasun/Documents/Workspace/da-bacom/nala/blocks/progressive-profiling/progressive-profiling.page.js)
+
+## What the suite covers
+
+- `@staged`: staged PP test pages across locales
+- `@ongoing`: live ongoing PP pages
+- `@out-of-scope`: pages that should not show PP behavior
+- `@journey`: manual email-link flows
+- `@pp`: umbrella tag for the entire PP suite
+
+## Environment variables
+
+- `LOCAL_TEST_LIVE_URL`
+  - Standard Nala base URL for the repo under test
+  - Example for stage preview validation:
+    - `https://stage--da-bacom--adobecom.aem.live`
+- `PP_BUSINESS_ORIGIN`
+  - Business site origin used by the PP URLs in the spec
+  - Defaults to `https://business.stage.adobe.com`
+  - Set this to prod when you want to run the business URLs on production
+- `PP_REVISIT_DELAY_MS`
+  - Optional override for the known-visitor wait time before revisit validation
+  - Default is `60000`
+
+## Run on stage
+
+Run the whole PP suite on Chromium:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
+PP_BUSINESS_ORIGIN=https://business.stage.adobe.com \
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js \
+--project=da-bacom-live-chromium --grep @pp
+```
+
+Run only the ongoing pages on Safari desktop:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
+PP_BUSINESS_ORIGIN=https://business.stage.adobe.com \
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js \
+--project=da-bacom-live-webkit --grep @ongoing
+```
+
+Run only the out-of-scope pages on Firefox:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
+PP_BUSINESS_ORIGIN=https://business.stage.adobe.com \
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js \
+--project=da-bacom-live-firefox --grep @out-of-scope
+```
+
+## Run on prod
+
+To point the business URLs at prod, change only `PP_BUSINESS_ORIGIN`:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://www.adobe.com \
+PP_BUSINESS_ORIGIN=https://business.adobe.com \
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js \
+--project=da-bacom-live-chromium --grep @ongoing
+```
+
+Example for prod out-of-scope validation:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://www.adobe.com \
+PP_BUSINESS_ORIGIN=https://business.adobe.com \
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js \
+--project=da-bacom-live-webkit --grep @out-of-scope
+```
+
+## Recommended targeted runs
+
+Run only the PP suite:
+
+```bash
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js --grep @pp
+```
+
+Run only one test:
+
+```bash
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js \
+--grep @PP-Ongoing-US-RequestConsultation
+```
+
+Run only multistep out-of-scope pages:
+
+```bash
+npx playwright test nala/blocks/progressive-profiling/progressive-profiling.test.js \
+--grep "@out-of-scope|@multi-step"
+```
+
+## PR behavior
+
+PP tests are tagged with `@pp`.
+
+Default PR Nala runs exclude `@pp` through:
+
+- [pr.run.sh](/Users/xiasun/Documents/Workspace/da-bacom/nala/utils/pr.run.sh)
+
+That means:
+
+- PP tests do not run in default PR Nala execution
+- PP tests can still be run manually on purpose with `--grep @pp`
+
+## Notes
+
+- `@journey` tests are manual and also tagged `@nopr`, so they are not part of default PR automation
+- If you want faster revisit checks during local debugging, set `PP_REVISIT_DELAY_MS` to a smaller value

--- a/nala/blocks/progressive-profiling/README.md
+++ b/nala/blocks/progressive-profiling/README.md
@@ -1,11 +1,5 @@
 # Progressive Profiling Nala Tests
 
-This suite lives in:
-
-- [progressive-profiling.spec.js](/Users/xiasun/Documents/Workspace/da-bacom/nala/blocks/progressive-profiling/progressive-profiling.spec.js)
-- [progressive-profiling.test.js](/Users/xiasun/Documents/Workspace/da-bacom/nala/blocks/progressive-profiling/progressive-profiling.test.js)
-- [progressive-profiling.page.js](/Users/xiasun/Documents/Workspace/da-bacom/nala/blocks/progressive-profiling/progressive-profiling.page.js)
-
 ## What the suite covers
 
 - `@staged`: staged PP test pages across locales

--- a/nala/blocks/progressive-profiling/progressive-profiling.page.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.page.js
@@ -1,5 +1,7 @@
 import { expect } from '@playwright/test';
 
+const GENERIC_FORM_TIMEOUT_MS = Number(process.env.PP_FORM_LOAD_TIMEOUT_MS || '120000');
+
 /**
  * Progressive Profiling Form Page Object
  * Handles form field interactions and validations for progressive profiling tests
@@ -51,6 +53,7 @@ import { expect } from '@playwright/test';
 export default class ProgressiveProfilingForm {
   constructor(page) {
     this.page = page;
+    this.formRoot = this.page.locator('.marketo, form').first();
     this.marketo = this.page.locator('.marketo');
 
     // ==========================================================================
@@ -84,7 +87,10 @@ export default class ProgressiveProfilingForm {
     // ==========================================================================
     // Form elements
     // ==========================================================================
-    this.submitButton = this.marketo.locator('#mktoButton_new');
+    this.submitButton = this.marketo.locator('#mktoButton_new, .mktoButton, button[type="submit"]').first();
+    this.anySubmitButton = this.page.locator('form button[type="submit"], form input[type="submit"], .mktoButton').first();
+    this.nextStepButton = this.page.locator('button#mktoButton_next, .mktoButtonRow button#mktoButton_next').first();
+    this.stepDetails = this.page.locator('.step-details .step').first();
     this.formTitle = this.marketo.locator('.marketo-title');
     this.formDescription = this.marketo.locator('.marketo-description');
     this.errorMessage = this.marketo.locator('.msg-error');
@@ -105,9 +111,67 @@ export default class ProgressiveProfilingForm {
     };
   }
 
+  async goto(url, waitForMarketo = true) {
+    await this.page.goto(url);
+    await this.page.waitForLoadState('domcontentloaded');
+
+    if (waitForMarketo) {
+      await this.waitForFormLoad();
+      return;
+    }
+
+    await this.waitForAnyFormLoad();
+  }
+
+  async waitForAnyFormLoad() {
+    await expect(async () => {
+      await this.page.evaluate(() => {
+        const marketoAnchor = document.querySelector('.marketo-form-wrapper, .marketo.multi-step, .marketo, [class*="marketo"]');
+        if (marketoAnchor) {
+          marketoAnchor.scrollIntoView({ block: 'center', behavior: 'instant' });
+          return;
+        }
+
+        window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' });
+      }).catch(() => {});
+
+      const visibleFormCount = await this.getGenericVisibleFormCount();
+      expect(visibleFormCount).toBeGreaterThan(0);
+    }).toPass({ timeout: GENERIC_FORM_TIMEOUT_MS });
+
+    await expect(async () => {
+      const visibleFieldCount = await this.getGenericVisibleFieldCount();
+      expect(visibleFieldCount).toBeGreaterThan(0);
+    }).toPass({ timeout: GENERIC_FORM_TIMEOUT_MS });
+  }
+
   async waitForFormLoad() {
-    await this.marketo.waitFor({ state: 'visible', timeout: 30000 });
-    await this.email.waitFor({ state: 'visible', timeout: 30000 });
+    try {
+      await this.marketo.waitFor({ state: 'visible', timeout: 30000 });
+      await this.email.waitFor({ state: 'visible', timeout: 30000 });
+      return;
+    } catch (error) {
+      // Some live Marketo pages render the shell first and hydrate fields later.
+      await this.waitForAnyFormLoad();
+
+      const recoveryLocators = [
+        this.email,
+        this.firstName,
+        this.company,
+        this.country,
+        this.submitButton,
+      ];
+
+      const recovered = await Promise.all(
+        recoveryLocators.map((locator) => locator.isVisible().catch(() => false)),
+      );
+
+      if (recovered.some(Boolean)) {
+        return;
+      }
+
+      throw error;
+    }
   }
 
   async getFormTemplate() {
@@ -256,18 +320,202 @@ export default class ProgressiveProfilingForm {
     await this.submitButton.click();
   }
 
-  async submitAndWaitForRedirect() {
+  async submitAndCheckValidationErrors() {
     await this.submitForm();
+    await this.page.waitForTimeout(1000);
+    return this.hasValidationErrors();
+  }
+
+  async submitAnyForm() {
+    await this.anySubmitButton.click();
+  }
+
+  async submitAnyFormAndCheckValidationErrors() {
+    await this.submitAnyForm();
+    await this.page.waitForTimeout(1000);
+    return this.hasAnyValidationErrors();
+  }
+
+  async submitAnyFormAndWaitForSuccess() {
+    const startingUrl = this.page.url();
+    await this.submitAnyForm();
 
     try {
       await expect(async () => {
-        await this.submitButton.waitFor({ state: 'detached', timeout: 30000 });
         const currentUrl = this.page.url();
-        expect(currentUrl).toContain('submissionid');
+        const thankYouMessage = await this.page.locator('.ty-message, [class*="thank"], [class*="success"]').count();
+        const formVisible = await this.formRoot.isVisible().catch(() => false);
+
+        expect(
+          currentUrl !== startingUrl
+            || currentUrl.includes('submissionid')
+            || thankYouMessage > 0
+            || formVisible === false,
+        ).toBe(true);
       }).toPass({ timeout: 60000 });
       return true;
     } catch {
       return false;
+    }
+  }
+
+  async submitAndWaitForRedirect() {
+    const startingUrl = this.page.url();
+    await this.submitForm();
+
+    try {
+      await expect(async () => {
+        const currentUrl = this.page.url();
+        const thankYouMessage = await this.page.locator('.ty-message, [class*="thank"], [class*="success"]').count();
+        const submitButtonVisible = await this.submitButton.isVisible().catch(() => false);
+        const visibleFormCount = await this.getGenericVisibleFormCount().catch(() => 0);
+
+        expect(
+          currentUrl !== startingUrl
+            || currentUrl.includes('submissionid')
+            || thankYouMessage > 0
+            || submitButtonVisible === false
+            || visibleFormCount === 0,
+        ).toBe(true);
+      }).toPass({ timeout: 60000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async hasValidationErrors() {
+    const invalidStateCount = await this.marketo.locator('[aria-invalid="true"], .mktoInvalid, .mktoError, .mktoErrorMsg, .msg-error').count();
+    return invalidStateCount > 0;
+  }
+
+  async hasAnyValidationErrors() {
+    const invalidStateCount = await this.page.locator('form [aria-invalid="true"], form .mktoInvalid, form .mktoError, form .mktoErrorMsg, form .msg-error, form :invalid').count();
+    return invalidStateCount > 0;
+  }
+
+  async getCurrentStep() {
+    const formWithStep = this.page.locator('form[data-step]').first();
+    const dataStep = await formWithStep.getAttribute('data-step').catch(() => null);
+    if (dataStep) {
+      return Number(dataStep);
+    }
+
+    const stepText = await this.stepDetails.textContent().catch(() => '');
+    const match = stepText?.match(/Step\s+(\d+)\s+of\s+\d+/i);
+    return match ? Number(match[1]) : null;
+  }
+
+  async clickNextStep() {
+    await this.nextStepButton.click();
+  }
+
+  async waitForStepChange(previousStep) {
+    await expect(async () => {
+      const currentStep = await this.getCurrentStep();
+      expect(currentStep).toBe(previousStep + 1);
+    }).toPass({ timeout: 30000 });
+  }
+
+  async selectVisibleOption(field, preferredLabel) {
+    if (preferredLabel) {
+      try {
+        await field.selectOption({ label: preferredLabel });
+        return true;
+      } catch {
+        // Fall back to the first non-empty option once the field is populated.
+      }
+    }
+
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const optionCount = await field.evaluate((element) => element.options?.length || 0).catch(() => 0);
+      if (optionCount > 1) {
+        try {
+          await field.selectOption({ index: 1 });
+          return true;
+        } catch {
+          // Keep polling while dependent options are still stabilizing.
+        }
+      }
+
+      await this.page.waitForTimeout(250);
+    }
+
+    return false;
+  }
+
+  async fillVisibleRequiredFields(userData) {
+    const visibleFields = await this.page.locator('form input, form select, form textarea').elementHandles();
+    const fieldValues = {
+      Email: userData.email,
+      FirstName: userData.firstName,
+      LastName: userData.lastName,
+      mktoFormsCompany: userData.company,
+      Phone: userData.phone,
+      PostalCode: userData.postalCode,
+      Country: userData.country,
+      State: userData.state,
+      mktoFormsJobTitle: userData.jobTitle,
+      mktoFormsFunctionalArea: userData.functionalArea,
+      mktoFormsPrimaryProductInterest: userData.primaryProductInterest,
+    };
+
+    for (const field of visibleFields) {
+      const isVisible = await field.isVisible().catch(() => false);
+      const disabled = await field.isDisabled().catch(() => false);
+      if (isVisible && !disabled) {
+        const required = await field.evaluate((element) => {
+          const htmlElement = element;
+          const fieldContainer = htmlElement.closest('.mktoFieldDescriptor, .mktoFieldWrap, .mktoFormRow, .mktoFormCol');
+          return htmlElement.required
+            || htmlElement.getAttribute('aria-required') === 'true'
+            || htmlElement.classList.contains('mktoRequired')
+            || fieldContainer?.classList?.contains('mktoRequired')
+            || fieldContainer?.classList?.contains('mktoRequiredField')
+            || fieldContainer?.querySelector?.('.mktoAsterix') !== null
+            || fieldContainer?.querySelector?.('label.mktoLabel .mktoAsterix') !== null;
+        }).catch(() => false);
+
+        if (required) {
+          const tagName = await field.evaluate((element) => element.tagName.toLowerCase());
+          const type = await field.getAttribute('type');
+          const name = await field.getAttribute('name');
+          const isCloneField = name?.endsWith('_clone');
+
+          if (type !== 'hidden' && !isCloneField) {
+            if (tagName === 'select') {
+              if (name === 'Country') {
+                const selectedCountry = await this.selectVisibleOption(field, userData.country);
+                if (!selectedCountry) {
+                  await field.selectOption({ value: 'US' }).catch(() => {});
+                }
+              } else if (name === 'State') {
+                await this.selectVisibleOption(field, userData.state);
+              } else if (fieldValues[name]) {
+                await this.selectVisibleOption(field, fieldValues[name]);
+              } else {
+                await this.selectVisibleOption(field);
+              }
+            } else if (type === 'checkbox' || type === 'radio') {
+              await field.check().catch(() => {});
+            } else {
+              const existingValue = await field.inputValue().catch(() => '');
+
+              if (!existingValue) {
+                let value = fieldValues[name];
+                if (!value) {
+                  if (type === 'email') value = userData.email;
+                  else if (type === 'tel') value = userData.phone;
+                  else if (tagName === 'textarea') value = 'Nala regression test';
+                  else value = 'NalaTest';
+                }
+
+                await field.fill(value).catch(() => {});
+              }
+            }
+          }
+        }
+      }
     }
   }
 
@@ -335,6 +583,107 @@ export default class ProgressiveProfilingForm {
     }
 
     return results;
+  }
+
+  async getVisibleFieldNames(fieldNames = Object.keys(this.fieldMap)) {
+    const visibleFields = [];
+
+    for (const fieldName of fieldNames) {
+      if (await this.isFieldVisible(fieldName)) {
+        visibleFields.push(fieldName);
+      }
+    }
+
+    return visibleFields;
+  }
+
+  async getKnownVisitorEffects(fieldNames = Object.keys(this.fieldMap)) {
+    const details = [];
+    let count = 0;
+
+    for (const fieldName of fieldNames) {
+      const isVisible = await this.isFieldVisible(fieldName);
+      const isPrefilled = isVisible ? await this.isFieldPrefilled(fieldName) : false;
+      const hasEffect = !isVisible || isPrefilled;
+
+      if (hasEffect) {
+        count += 1;
+      }
+
+      let actual = 'visible-empty';
+      if (!isVisible) {
+        actual = 'hidden';
+      } else if (isPrefilled) {
+        actual = 'prefilled';
+      }
+
+      details.push({
+        field: fieldName,
+        actual,
+      });
+    }
+
+    return { count, details };
+  }
+
+  async getGenericVisibleFormCount() {
+    return this.page.evaluate(() => [...document.querySelectorAll('form')]
+      .filter((form) => {
+        const style = window.getComputedStyle(form);
+        const rect = form.getBoundingClientRect();
+        return style.display !== 'none'
+          && style.visibility !== 'hidden'
+          && style.opacity !== '0'
+          && rect.width > 0
+          && rect.height > 0;
+      }).length);
+  }
+
+  async getGenericVisibleFieldCount() {
+    return this.page.evaluate(() => [...document.querySelectorAll('form input, form select, form textarea')]
+      .filter((element) => {
+        if (element instanceof HTMLInputElement && element.type === 'hidden') {
+          return false;
+        }
+
+        if (element.name?.endsWith('_clone')) {
+          return false;
+        }
+
+        const form = element.closest('form');
+        if (!form) {
+          return false;
+        }
+
+        const formStyle = window.getComputedStyle(form);
+        const formRect = form.getBoundingClientRect();
+        if (
+          formStyle.display === 'none'
+          || formStyle.visibility === 'hidden'
+          || formStyle.opacity === '0'
+          || formRect.width === 0
+          || formRect.height === 0
+        ) {
+          return false;
+        }
+
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        return style.display !== 'none'
+          && style.visibility !== 'hidden'
+          && style.opacity !== '0'
+          && rect.width > 0
+          && rect.height > 0;
+      }).length);
+  }
+
+  async captureFormSignature(fieldNames = Object.keys(this.fieldMap)) {
+    await this.waitForAnyFormLoad();
+
+    return {
+      genericVisibleFieldCount: await this.getGenericVisibleFieldCount(),
+      marketoVisibleFields: await this.getVisibleFieldNames(fieldNames),
+    };
   }
 
   async logFormState() {

--- a/nala/blocks/progressive-profiling/progressive-profiling.page.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.page.js
@@ -1,0 +1,374 @@
+import { expect } from '@playwright/test';
+
+/**
+ * Progressive Profiling Form Page Object
+ * Handles form field interactions and validations for progressive profiling tests
+ *
+ * =============================================================================
+ * FORM FIELD SPECIFICATIONS
+ * =============================================================================
+ *
+ * Essential / Short (flex_content):
+ * - First name (FirstName)
+ * - Last name (LastName)
+ * - Business email (Email)
+ * - Organization name (mktoFormsCompany)
+ * - Country (Country)
+ * - Company type* (mktoFormsCompanyType) - Depends on POI
+ *
+ * Expanded / Medium (flex_event):
+ * - First name (FirstName)
+ * - Last name (LastName)
+ * - Business email (Email)
+ * - Job title or role (mktoFormsJobTitle)
+ * - Department (mktoFormsFunctionalArea)
+ * - Organization name (mktoFormsCompany)
+ * - Country (Country)
+ * - Company type* (mktoFormsCompanyType) - Depends on POI
+ *
+ * Full / Long (flex_contact / RFI):
+ * - First name (FirstName)
+ * - Last name (LastName)
+ * - Business email (Email)
+ * - Business phone (Phone)
+ * - Job Title or role (mktoFormsJobTitle)
+ * - Department (mktoFormsFunctionalArea)
+ * - Organization name (mktoFormsCompany)
+ * - Country (Country)
+ * - State/province (State)
+ * - Zip/postal code (PostalCode)
+ * - Primary product of interest (mktoFormsPrimaryProductInterest)
+ *
+ * =============================================================================
+ * PROGRESSIVE PROFILING RULES
+ * =============================================================================
+ *
+ * Previously collected fields become HIDDEN on subsequent forms:
+ * - Short → Medium: firstName, lastName, company become HIDDEN
+ * - Short → RFI: firstName, lastName, company become HIDDEN
+ * - Medium → RFI: firstName, lastName, company, jobTitle, department become HIDDEN
+ */
+export default class ProgressiveProfilingForm {
+  constructor(page) {
+    this.page = page;
+    this.marketo = this.page.locator('.marketo');
+
+    // ==========================================================================
+    // Core fields (Short/Essential form - flex_content)
+    // ==========================================================================
+    this.email = this.marketo.locator('input[name="Email"]');
+    this.firstName = this.marketo.locator('input[name="FirstName"]');
+    this.lastName = this.marketo.locator('input[name="LastName"]');
+    this.company = this.marketo.locator('input[name="mktoFormsCompany"]');
+    this.country = this.marketo.locator('select[name="Country"]');
+
+    // ==========================================================================
+    // Medium/Expanded form fields (flex_event) - additional fields
+    // ==========================================================================
+    this.jobTitle = this.marketo.locator('select[name="mktoFormsJobTitle"]');
+    this.functionalArea = this.marketo.locator('select[name="mktoFormsFunctionalArea"]');
+
+    // ==========================================================================
+    // RFI/Full form fields (flex_contact) - additional fields
+    // ==========================================================================
+    this.phone = this.marketo.locator('input[name="Phone"]');
+    this.state = this.marketo.locator('select[name="State"]');
+    this.postalCode = this.marketo.locator('input[name="PostalCode"]');
+    this.primaryProductInterest = this.marketo.locator('select[name="mktoFormsPrimaryProductInterest"]');
+
+    // ==========================================================================
+    // Conditional field (depends on POI)
+    // ==========================================================================
+    this.companyType = this.marketo.locator('select[name="mktoFormsCompanyType"]');
+
+    // ==========================================================================
+    // Form elements
+    // ==========================================================================
+    this.submitButton = this.marketo.locator('#mktoButton_new');
+    this.formTitle = this.marketo.locator('.marketo-title');
+    this.formDescription = this.marketo.locator('.marketo-description');
+    this.errorMessage = this.marketo.locator('.msg-error');
+
+    this.fieldMap = {
+      email: this.email,
+      firstName: this.firstName,
+      lastName: this.lastName,
+      company: this.company,
+      country: this.country,
+      jobTitle: this.jobTitle,
+      functionalArea: this.functionalArea,
+      phone: this.phone,
+      state: this.state,
+      postalCode: this.postalCode,
+      primaryProductInterest: this.primaryProductInterest,
+      companyType: this.companyType,
+    };
+  }
+
+  async waitForFormLoad() {
+    await this.marketo.waitFor({ state: 'visible', timeout: 30000 });
+    await this.email.waitFor({ state: 'visible', timeout: 30000 });
+  }
+
+  async getFormTemplate() {
+    const template = await this.page.evaluate(
+      'window.mcz_marketoForm_pref?.form?.template',
+    );
+    return template || 'unknown';
+  }
+
+  async getPOI() {
+    const poi = await this.page.evaluate(
+      'window.mcz_marketoForm_pref?.program?.poi',
+    );
+    return poi || '';
+  }
+
+  async isFieldVisible(fieldName) {
+    const field = this.fieldMap[fieldName];
+    if (!field) {
+      console.warn(`[PP] Unknown field: ${fieldName}`);
+      return false;
+    }
+
+    try {
+      const isVisible = await field.isVisible({ timeout: 5000 });
+      return isVisible;
+    } catch {
+      return false;
+    }
+  }
+
+  async isFieldHidden(fieldName) {
+    return !(await this.isFieldVisible(fieldName));
+  }
+
+  async isFieldPrefilled(fieldName) {
+    const field = this.fieldMap[fieldName];
+    if (!field) {
+      console.warn(`[PP] Unknown field: ${fieldName}`);
+      return false;
+    }
+
+    try {
+      const isVisible = await field.isVisible({ timeout: 3000 });
+      if (!isVisible) return false;
+
+      const tagName = await field.evaluate((el) => el.tagName.toLowerCase());
+
+      if (tagName === 'select') {
+        const selectedValue = await field.inputValue();
+        return selectedValue !== '' && selectedValue !== '0';
+      }
+      const value = await field.inputValue();
+      return value !== '' && value.length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  async getFieldValue(fieldName) {
+    const field = this.fieldMap[fieldName];
+    if (!field) return '';
+
+    try {
+      const isVisible = await field.isVisible({ timeout: 3000 });
+      if (!isVisible) return '';
+
+      return await field.inputValue();
+    } catch {
+      return '';
+    }
+  }
+
+  async fillField(fieldName, value) {
+    const field = this.fieldMap[fieldName];
+    if (!field) {
+      console.warn(`[PP] Unknown field: ${fieldName}`);
+      return;
+    }
+
+    const tagName = await field.evaluate((el) => el.tagName.toLowerCase());
+
+    if (tagName === 'select') {
+      try {
+        await field.selectOption({ label: value });
+      } catch {
+        await field.selectOption({ index: 1 });
+      }
+    } else {
+      await field.fill(value);
+    }
+  }
+
+  /**
+   * Fill the Short/Essential form (flex_content)
+   * Fields: email, firstName, lastName, company, country
+   */
+  async fillShortForm(userData) {
+    await this.fillField('email', userData.email);
+    await this.fillField('firstName', userData.firstName);
+    await this.fillField('lastName', userData.lastName);
+    await this.fillField('company', userData.company);
+    await this.fillField('country', userData.country);
+  }
+
+  /**
+   * Fill the Medium/Expanded form (flex_event)
+   * Fields: email, firstName, lastName, company, country, jobTitle, functionalArea
+   */
+  async fillMediumForm(userData) {
+    await this.fillShortForm(userData);
+    await this.fillField('jobTitle', userData.jobTitle);
+    await this.fillField('functionalArea', userData.functionalArea);
+  }
+
+  /**
+   * Fill the RFI/Full form (flex_contact)
+   * Fields: ALL
+   */
+  async fillRfiForm(userData) {
+    await this.fillMediumForm(userData);
+    await this.fillField('phone', userData.phone);
+    await this.fillField('state', userData.state);
+    await this.fillField('postalCode', userData.postalCode);
+    await this.fillField('primaryProductInterest', userData.primaryProductInterest);
+  }
+
+  async fillVisibleFields(userData, fieldsToFill) {
+    for (const fieldName of fieldsToFill) {
+      const isVisible = await this.isFieldVisible(fieldName);
+      if (isVisible && userData[fieldName]) {
+        await this.fillField(fieldName, userData[fieldName]);
+      }
+    }
+  }
+
+  async fillProgressiveFields(userData, newFields) {
+    for (const fieldName of newFields) {
+      if (userData[fieldName]) {
+        await this.fillField(fieldName, userData[fieldName]);
+      }
+    }
+  }
+
+  async submitForm() {
+    await this.submitButton.click();
+  }
+
+  async submitAndWaitForRedirect() {
+    await this.submitForm();
+
+    try {
+      await expect(async () => {
+        await this.submitButton.waitFor({ state: 'detached', timeout: 30000 });
+        const currentUrl = this.page.url();
+        expect(currentUrl).toContain('submissionid');
+      }).toPass({ timeout: 60000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async verifyFieldVisibility(expectedVisible, expectedHidden) {
+    const results = {
+      passed: 0,
+      failed: 0,
+      details: [],
+    };
+
+    for (const fieldName of expectedVisible) {
+      const isVisible = await this.isFieldVisible(fieldName);
+      if (isVisible) {
+        results.passed += 1;
+        results.details.push({ field: fieldName, expected: 'visible', actual: 'visible', pass: true });
+      } else {
+        results.failed += 1;
+        results.details.push({ field: fieldName, expected: 'visible', actual: 'hidden', pass: false });
+      }
+    }
+
+    for (const fieldName of expectedHidden) {
+      const isHidden = await this.isFieldHidden(fieldName);
+      if (isHidden) {
+        results.passed += 1;
+        results.details.push({ field: fieldName, expected: 'hidden', actual: 'hidden', pass: true });
+      } else {
+        results.failed += 1;
+        results.details.push({ field: fieldName, expected: 'hidden', actual: 'visible', pass: false });
+      }
+    }
+
+    return results;
+  }
+
+  async verifyFieldPrefill(expectedPrefilled, expectedEmpty) {
+    const results = {
+      passed: 0,
+      failed: 0,
+      details: [],
+    };
+
+    for (const fieldName of expectedPrefilled) {
+      const isPrefilled = await this.isFieldPrefilled(fieldName);
+      if (isPrefilled) {
+        results.passed += 1;
+        const value = await this.getFieldValue(fieldName);
+        results.details.push({ field: fieldName, expected: 'prefilled', actual: `prefilled (${value})`, pass: true });
+      } else {
+        results.failed += 1;
+        results.details.push({ field: fieldName, expected: 'prefilled', actual: 'empty', pass: false });
+      }
+    }
+
+    for (const fieldName of expectedEmpty) {
+      const isPrefilled = await this.isFieldPrefilled(fieldName);
+      if (!isPrefilled) {
+        results.passed += 1;
+        results.details.push({ field: fieldName, expected: 'empty', actual: 'empty', pass: true });
+      } else {
+        results.failed += 1;
+        const value = await this.getFieldValue(fieldName);
+        results.details.push({ field: fieldName, expected: 'empty', actual: `prefilled (${value})`, pass: false });
+      }
+    }
+
+    return results;
+  }
+
+  async logFormState() {
+    console.info('[PP] Form State:');
+    console.info(`  Template: ${await this.getFormTemplate()}`);
+    console.info(`  POI: ${await this.getPOI()}`);
+
+    for (const [name, field] of Object.entries(this.fieldMap)) {
+      try {
+        const isVisible = await field.isVisible({ timeout: 1000 });
+        if (isVisible) {
+          const value = await field.inputValue();
+          console.info(`  ${name}: visible, value="${value}"`);
+        } else {
+          console.info(`  ${name}: hidden`);
+        }
+      } catch {
+        console.info(`  ${name}: not found`);
+      }
+    }
+  }
+
+  async clearUserState() {
+    await this.page.context().clearCookies();
+  }
+
+  async clearStorageOnPage() {
+    try {
+      await this.page.evaluate(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+      });
+    } catch (e) {
+      console.info('[PP] Could not clear storage (may be expected):', e.message);
+    }
+  }
+}

--- a/nala/blocks/progressive-profiling/progressive-profiling.page.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.page.js
@@ -16,7 +16,6 @@ const GENERIC_FORM_TIMEOUT_MS = Number(process.env.PP_FORM_LOAD_TIMEOUT_MS || '1
  * - Business email (Email)
  * - Organization name (mktoFormsCompany)
  * - Country (Country)
- * - Company type* (mktoFormsCompanyType) - Depends on POI
  *
  * Expanded / Medium (flex_event):
  * - First name (FirstName)
@@ -26,7 +25,6 @@ const GENERIC_FORM_TIMEOUT_MS = Number(process.env.PP_FORM_LOAD_TIMEOUT_MS || '1
  * - Department (mktoFormsFunctionalArea)
  * - Organization name (mktoFormsCompany)
  * - Country (Country)
- * - Company type* (mktoFormsCompanyType) - Depends on POI
  *
  * Full / Long (flex_contact / RFI):
  * - First name (FirstName)
@@ -80,11 +78,6 @@ export default class ProgressiveProfilingForm {
     this.primaryProductInterest = this.marketo.locator('select[name="mktoFormsPrimaryProductInterest"]');
 
     // ==========================================================================
-    // Conditional field (depends on POI)
-    // ==========================================================================
-    this.companyType = this.marketo.locator('select[name="mktoFormsCompanyType"]');
-
-    // ==========================================================================
     // Form elements
     // ==========================================================================
     this.submitButton = this.marketo.locator('#mktoButton_new, .mktoButton, button[type="submit"]').first();
@@ -107,7 +100,6 @@ export default class ProgressiveProfilingForm {
       state: this.state,
       postalCode: this.postalCode,
       primaryProductInterest: this.primaryProductInterest,
-      companyType: this.companyType,
     };
   }
 

--- a/nala/blocks/progressive-profiling/progressive-profiling.spec.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.spec.js
@@ -1,161 +1,181 @@
-/**
- * BACOM Progressive Profiling Feature Definitions
- *
- * Test Coverage:
- * - Unknown user field visibility across all form types
- * - Known user pre-fill and progressive field behavior
- * - Form journeys: Short→Medium, Short→RFI, Medium→RFI
- *
- * Form Types:
- * - Short (Essential DX): Basic fields (Email, Name, Company, Country)
- * - Medium (Expanded DX): Basic + Job fields (JobTitle, FunctionalArea)
- * - RFI (Contact/Full): All fields including contact details
- *
- * Browser/Platform Requirements (Non-Functional):
- * - Chrome (Desktop) - Primary browser
- * - Firefox (Desktop)
- * - Safari/WebKit (Desktop)
- *
- * Email Requirement:
- * - Use @adobetest.com emails (e.g., xiasun+test001@adobetest.com)
- */
+const BUSINESS_STAGE_ORIGIN = 'https://business.stage.adobe.com';
+
+const STAGED_LOCALES = [
+  { code: 'US', path: '', tag: '@us' },
+  { code: 'UK', path: '/uk', tag: '@uk' },
+  { code: 'AU', path: '/au', tag: '@au' },
+  { code: 'JP', path: '/jp', tag: '@jp' },
+  { code: 'PT', path: '/pt', tag: '@pt' },
+  { code: 'KR', path: '/kr', tag: '@kr' },
+  { code: 'IT', path: '/it', tag: '@it' },
+  { code: 'ES', path: '/es', tag: '@es' },
+  { code: 'FR', path: '/fr', tag: '@fr' },
+  { code: 'DE', path: '/de', tag: '@de' },
+  { code: 'IN', path: '/in', tag: '@in' },
+];
+
+const STAGED_FORMS = [
+  {
+    key: 'Short',
+    formType: 'short',
+    urlPath: '/resources/form-test-1-essential-dx-stage.html',
+    description: 'Unknown visitor sees the full Essential/Short field set on the staged test page.',
+    tags: '@bacom @progressive-profiling @pp @staged @short @smoke @regression',
+    unknownVisitor: {
+      visible: ['email', 'firstName', 'lastName', 'company', 'country'],
+      hidden: ['state', 'postalCode', 'phone', 'jobTitle', 'functionalArea', 'primaryProductInterest'],
+    },
+    revisitPrefill: ['email', 'firstName', 'lastName', 'company', 'country'],
+  },
+  {
+    key: 'Medium',
+    formType: 'medium',
+    urlPath: '/resources/form-test-2-expanded-dx-stage.html',
+    description: 'Unknown visitor sees the full Expanded/Medium field set on the staged test page.',
+    tags: '@bacom @progressive-profiling @pp @staged @medium @smoke @regression',
+    unknownVisitor: {
+      visible: ['email', 'firstName', 'lastName', 'company', 'country', 'jobTitle', 'functionalArea'],
+      hidden: ['state', 'postalCode', 'phone', 'primaryProductInterest'],
+    },
+    revisitPrefill: ['email', 'firstName', 'lastName', 'company', 'country', 'jobTitle', 'functionalArea'],
+  },
+  {
+    key: 'Full',
+    formType: 'rfi',
+    urlPath: '/resources/form-test-5-stage.html',
+    description: 'Unknown visitor sees the full Contact/Full field set on the staged test page.',
+    tags: '@bacom @progressive-profiling @pp @staged @full @smoke @regression',
+    unknownVisitor: {
+      visible: ['email', 'firstName', 'lastName', 'company', 'country', 'phone', 'jobTitle', 'functionalArea', 'primaryProductInterest'],
+      hidden: [],
+      visibleAfterCountry: ['state', 'postalCode'],
+    },
+    revisitPrefill: ['email', 'firstName', 'lastName', 'company', 'country', 'phone', 'jobTitle', 'functionalArea', 'primaryProductInterest', 'state', 'postalCode'],
+  },
+];
+
+function buildStageUrl(localePath, pagePath) {
+  return `${BUSINESS_STAGE_ORIGIN}${localePath}${pagePath}`;
+}
+
+const stagedPages = STAGED_LOCALES.flatMap((locale, localeIndex) => STAGED_FORMS.map((form, formIndex) => ({
+  tcid: `PP-STAGE-${String((localeIndex * STAGED_FORMS.length) + formIndex + 1).padStart(2, '0')}`,
+  name: `@PP-Staged-${locale.code}-${form.key}`,
+  url: buildStageUrl(locale.path, form.urlPath),
+  formType: form.formType,
+  description: `${locale.code} staged test page. ${form.description}`,
+  tags: `${form.tags} ${locale.tag}`,
+  unknownVisitor: form.unknownVisitor,
+  revisitPrefill: form.revisitPrefill,
+})));
 
 module.exports = {
   name: 'BACOM Progressive Profiling',
-  features: [
-    // =========================================================================
-    // UNKNOWN USER TESTS - Verify all fields are visible, no pre-fill
-    // =========================================================================
+  stagedPages,
+  journeyFlows: [
     {
-      tcid: '0',
-      name: '@PP-Unknown-ShortForm-DX',
-      url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
-      description: 'Unknown user visits Short DX form - all Short fields visible, no pre-fill',
-      tags: '@bacom @progressive-profiling @unknown @short @dx @smoke @regression',
-      formType: 'short',
-      userState: 'unknown',
+      tcid: 'PP-JOURNEY-01',
+      name: '@PP-Essential-To-Expanded',
+      sourceFormType: 'short',
+      destinationFormType: 'medium',
+      sourceUrl: buildStageUrl('', '/resources/form-test-1-essential-dx-stage.html'),
+      destinationUrl: buildStageUrl('', '/resources/form-test-2-expanded-dx-stage.html'),
+      description: 'Submit Essential/Short, validate PP behavior on Expanded/Medium via email link.',
+      tags: '@bacom @progressive-profiling @pp @journey @short-to-medium @manual @nopr @regression',
+      expectedHidden: ['firstName', 'lastName', 'company'],
+      expectedVisible: ['email', 'country', 'jobTitle', 'functionalArea'],
     },
     {
-      tcid: '1',
-      name: '@PP-Unknown-MediumForm-DX',
-      url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
-      description: 'Unknown user visits Medium DX form - all Medium fields visible, no pre-fill',
-      tags: '@bacom @progressive-profiling @unknown @medium @dx @smoke @regression',
-      formType: 'medium',
-      userState: 'unknown',
+      tcid: 'PP-JOURNEY-02',
+      name: '@PP-Essential-To-Full',
+      sourceFormType: 'short',
+      destinationFormType: 'rfi',
+      sourceUrl: buildStageUrl('', '/resources/form-test-1-essential-dx-stage.html'),
+      destinationUrl: buildStageUrl('', '/resources/form-test-5-stage.html'),
+      description: 'Submit Essential/Short, validate PP behavior on Full/RFI via email link.',
+      tags: '@bacom @progressive-profiling @pp @journey @short-to-rfi @manual @nopr @regression',
+      expectedHidden: ['firstName', 'lastName', 'company'],
+      expectedVisible: ['email', 'country', 'phone', 'state', 'postalCode', 'jobTitle', 'functionalArea', 'primaryProductInterest'],
     },
     {
-      tcid: '2',
-      name: '@PP-Unknown-RFIForm',
-      url: 'https://business.adobe.com/resources/form-test-5-stage.html',
-      description: 'Unknown user visits RFI form - all RFI fields visible, no pre-fill',
-      tags: '@bacom @progressive-profiling @unknown @rfi @smoke @regression',
-      formType: 'rfi',
-      userState: 'unknown',
+      tcid: 'PP-JOURNEY-03',
+      name: '@PP-Expanded-To-Full',
+      sourceFormType: 'medium',
+      destinationFormType: 'rfi',
+      sourceUrl: buildStageUrl('', '/resources/form-test-2-expanded-dx-stage.html'),
+      destinationUrl: buildStageUrl('', '/resources/form-test-5-stage.html'),
+      description: 'Submit Expanded/Medium, validate PP behavior on Full/RFI via email link.',
+      tags: '@bacom @progressive-profiling @pp @journey @medium-to-rfi @manual @nopr @regression',
+      expectedHidden: ['firstName', 'lastName', 'company', 'jobTitle', 'functionalArea'],
+      expectedVisible: ['email', 'country', 'phone', 'state', 'postalCode', 'primaryProductInterest'],
     },
-
-    // =========================================================================
-    // JOURNEY TESTS - Short to Medium Form
-    // =========================================================================
+  ],
+  ongoingPages: [
     {
-      tcid: '3',
-      name: '@PP-Journey-ShortToMedium',
-      description: 'User fills Short DX form, then visits Medium DX form - basic fields pre-filled',
-      tags: '@bacom @progressive-profiling @journey @short-to-medium @smoke @regression',
-      journey: {
-        firstForm: {
-          type: 'short',
-          url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
-        },
-        secondForm: {
-          type: 'medium',
-          url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
-        },
-      },
-    },
-
-    // =========================================================================
-    // JOURNEY TESTS - Short to RFI Form
-    // =========================================================================
-    {
-      tcid: '4',
-      name: '@PP-Journey-ShortToRFI',
-      description: 'User fills Short DX form, then visits RFI form - basic fields pre-filled',
-      tags: '@bacom @progressive-profiling @journey @short-to-rfi @smoke @regression',
-      journey: {
-        firstForm: {
-          type: 'short',
-          url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
-        },
-        secondForm: {
-          type: 'rfi',
-          url: 'https://business.adobe.com/resources/form-test-5-stage.html',
-        },
-      },
-    },
-
-    // =========================================================================
-    // JOURNEY TESTS - Medium to RFI Form
-    // =========================================================================
-    {
-      tcid: '5',
-      name: '@PP-Journey-MediumToRFI',
-      description: 'User fills Medium DX form, then visits RFI form',
-      tags: '@bacom @progressive-profiling @journey @medium-to-rfi @smoke @regression',
-      journey: {
-        firstForm: {
-          type: 'medium',
-          url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
-        },
-        secondForm: {
-          type: 'rfi',
-          url: 'https://business.adobe.com/resources/form-test-5-stage.html',
-        },
-      },
-    },
-
-    // =========================================================================
-    // FORM SUBMISSION TESTS - Verify form can be submitted successfully
-    // =========================================================================
-    {
-      tcid: '6',
-      name: '@PP-Submit-ShortForm',
-      description: 'Submit Short DX form and verify redirect to thank you page',
-      tags: '@bacom @progressive-profiling @submit @short @smoke @regression',
-      url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
-      formType: 'short',
-      testSubmission: true,
+      tcid: 'PP-ONGOING-00',
+      name: '@PP-Ongoing-US-RequestConsultation',
+      url: `${BUSINESS_STAGE_ORIGIN}/request-consultation.html`,
+      tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
     {
-      tcid: '7',
-      name: '@PP-Submit-MediumForm',
-      description: 'Submit Medium DX form and verify redirect to thank you page',
-      tags: '@bacom @progressive-profiling @submit @medium @smoke @regression',
-      url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
-      formType: 'medium',
-      testSubmission: true,
+      tcid: 'PP-ONGOING-01',
+      name: '@PP-Ongoing-AU-RequestConsultation',
+      url: `${BUSINESS_STAGE_ORIGIN}/au/request-consultation.html`,
+      tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
     {
-      tcid: '8',
-      name: '@PP-Submit-RFIForm',
-      description: 'Submit RFI form and verify redirect to thank you page',
-      tags: '@bacom @progressive-profiling @submit @rfi @smoke @regression',
-      url: 'https://business.adobe.com/resources/form-test-5-stage.html',
-      formType: 'rfi',
-      testSubmission: true,
+      tcid: 'PP-ONGOING-02',
+      name: '@PP-Ongoing-UK-RequestConsultation',
+      url: `${BUSINESS_STAGE_ORIGIN}/uk/request-consultation.html`,
+      tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
-
-    // =========================================================================
-    // EDGE CASE TESTS
-    // =========================================================================
     {
-      tcid: '9',
-      name: '@PP-EdgeCase-ClearedCookies',
-      description: 'Verify form behaves as unknown user after cookies are cleared',
-      tags: '@bacom @progressive-profiling @edge-case @regression',
-      url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
-      formType: 'medium',
-      testCookieClear: true,
+      tcid: 'PP-ONGOING-03',
+      name: '@PP-Ongoing-UK-BuildingStrongITFoundations',
+      url: `${BUSINESS_STAGE_ORIGIN}/uk/resources/webinars/building-strong-it-foundations.html`,
+      tags: '@bacom @progressive-profiling @pp @ongoing @regression',
+    },
+    {
+      tcid: 'PP-ONGOING-04',
+      name: '@PP-Ongoing-AU-AI',
+      url: `${BUSINESS_STAGE_ORIGIN}/au/ai.html`,
+      tags: '@bacom @progressive-profiling @pp @ongoing @regression',
+    },
+  ],
+  outOfScopePages: [
+    {
+      tcid: 'PP-OOS-01',
+      name: '@PP-OOS-Express-RequestInfo',
+      url: 'https://www.stage.adobe.com/express/business/request-info',
+      tags: '@bacom @progressive-profiling @pp @out-of-scope @regression',
+    },
+    {
+      tcid: 'PP-OOS-02',
+      name: '@PP-OOS-Acrobat-Contact',
+      url: 'https://www.adobe.com/acrobat/contact.html',
+      tags: '@bacom @progressive-profiling @pp @out-of-scope @regression',
+    },
+    {
+      tcid: 'PP-OOS-03',
+      name: '@PP-OOS-Acrobat-DeveloperForm',
+      url: 'https://www.adobe.com/acrobat/business/developer-form.html',
+      tags: '@bacom @progressive-profiling @pp @out-of-scope @regression',
+    },
+    {
+      tcid: 'PP-OOS-04',
+      name: '@PP-OOS-AgentOrchestrator',
+      url: `${BUSINESS_STAGE_ORIGIN}/products/experience-platform/agent-orchestrator.html`,
+      tags: '@bacom @progressive-profiling @pp @out-of-scope @multi-step @regression',
+      multiStep: true,
+      steps: 3,
+    },
+    {
+      tcid: 'PP-OOS-05',
+      name: '@PP-OOS-CreativeCloudBusiness',
+      url: `${BUSINESS_STAGE_ORIGIN}/products/creativecloud-business.html`,
+      tags: '@bacom @progressive-profiling @pp @out-of-scope @multi-step @regression',
+      multiStep: true,
+      steps: 3,
     },
   ],
 };

--- a/nala/blocks/progressive-profiling/progressive-profiling.spec.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.spec.js
@@ -1,4 +1,4 @@
-const BUSINESS_STAGE_ORIGIN = 'https://business.stage.adobe.com';
+const BUSINESS_ORIGIN = process.env.PP_BUSINESS_ORIGIN || 'https://business.stage.adobe.com';
 
 const STAGED_LOCALES = [
   { code: 'US', path: '', tag: '@us' },
@@ -54,14 +54,14 @@ const STAGED_FORMS = [
   },
 ];
 
-function buildStageUrl(localePath, pagePath) {
-  return `${BUSINESS_STAGE_ORIGIN}${localePath}${pagePath}`;
+function buildBusinessUrl(localePath, pagePath) {
+  return `${BUSINESS_ORIGIN}${localePath}${pagePath}`;
 }
 
 const stagedPages = STAGED_LOCALES.flatMap((locale, localeIndex) => STAGED_FORMS.map((form, formIndex) => ({
   tcid: `PP-STAGE-${String((localeIndex * STAGED_FORMS.length) + formIndex + 1).padStart(2, '0')}`,
   name: `@PP-Staged-${locale.code}-${form.key}`,
-  url: buildStageUrl(locale.path, form.urlPath),
+  url: buildBusinessUrl(locale.path, form.urlPath),
   formType: form.formType,
   description: `${locale.code} staged test page. ${form.description}`,
   tags: `${form.tags} ${locale.tag}`,
@@ -78,8 +78,8 @@ module.exports = {
       name: '@PP-Essential-To-Expanded',
       sourceFormType: 'short',
       destinationFormType: 'medium',
-      sourceUrl: buildStageUrl('', '/resources/form-test-1-essential-dx-stage.html'),
-      destinationUrl: buildStageUrl('', '/resources/form-test-2-expanded-dx-stage.html'),
+      sourceUrl: buildBusinessUrl('', '/resources/form-test-1-essential-dx-stage.html'),
+      destinationUrl: buildBusinessUrl('', '/resources/form-test-2-expanded-dx-stage.html'),
       description: 'Submit Essential/Short, validate PP behavior on Expanded/Medium via email link.',
       tags: '@bacom @progressive-profiling @pp @journey @short-to-medium @manual @nopr @regression',
       expectedHidden: ['firstName', 'lastName', 'company'],
@@ -90,8 +90,8 @@ module.exports = {
       name: '@PP-Essential-To-Full',
       sourceFormType: 'short',
       destinationFormType: 'rfi',
-      sourceUrl: buildStageUrl('', '/resources/form-test-1-essential-dx-stage.html'),
-      destinationUrl: buildStageUrl('', '/resources/form-test-5-stage.html'),
+      sourceUrl: buildBusinessUrl('', '/resources/form-test-1-essential-dx-stage.html'),
+      destinationUrl: buildBusinessUrl('', '/resources/form-test-5-stage.html'),
       description: 'Submit Essential/Short, validate PP behavior on Full/RFI via email link.',
       tags: '@bacom @progressive-profiling @pp @journey @short-to-rfi @manual @nopr @regression',
       expectedHidden: ['firstName', 'lastName', 'company'],
@@ -102,8 +102,8 @@ module.exports = {
       name: '@PP-Expanded-To-Full',
       sourceFormType: 'medium',
       destinationFormType: 'rfi',
-      sourceUrl: buildStageUrl('', '/resources/form-test-2-expanded-dx-stage.html'),
-      destinationUrl: buildStageUrl('', '/resources/form-test-5-stage.html'),
+      sourceUrl: buildBusinessUrl('', '/resources/form-test-2-expanded-dx-stage.html'),
+      destinationUrl: buildBusinessUrl('', '/resources/form-test-5-stage.html'),
       description: 'Submit Expanded/Medium, validate PP behavior on Full/RFI via email link.',
       tags: '@bacom @progressive-profiling @pp @journey @medium-to-rfi @manual @nopr @regression',
       expectedHidden: ['firstName', 'lastName', 'company', 'jobTitle', 'functionalArea'],
@@ -114,31 +114,31 @@ module.exports = {
     {
       tcid: 'PP-ONGOING-00',
       name: '@PP-Ongoing-US-RequestConsultation',
-      url: `${BUSINESS_STAGE_ORIGIN}/request-consultation.html`,
+      url: `${BUSINESS_ORIGIN}/request-consultation.html`,
       tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
     {
       tcid: 'PP-ONGOING-01',
       name: '@PP-Ongoing-AU-RequestConsultation',
-      url: `${BUSINESS_STAGE_ORIGIN}/au/request-consultation.html`,
+      url: `${BUSINESS_ORIGIN}/au/request-consultation.html`,
       tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
     {
       tcid: 'PP-ONGOING-02',
       name: '@PP-Ongoing-UK-RequestConsultation',
-      url: `${BUSINESS_STAGE_ORIGIN}/uk/request-consultation.html`,
+      url: `${BUSINESS_ORIGIN}/uk/request-consultation.html`,
       tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
     {
       tcid: 'PP-ONGOING-03',
       name: '@PP-Ongoing-UK-BuildingStrongITFoundations',
-      url: `${BUSINESS_STAGE_ORIGIN}/uk/resources/webinars/building-strong-it-foundations.html`,
+      url: `${BUSINESS_ORIGIN}/uk/resources/webinars/building-strong-it-foundations.html`,
       tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
     {
       tcid: 'PP-ONGOING-04',
       name: '@PP-Ongoing-AU-AI',
-      url: `${BUSINESS_STAGE_ORIGIN}/au/ai.html`,
+      url: `${BUSINESS_ORIGIN}/au/ai.html`,
       tags: '@bacom @progressive-profiling @pp @ongoing @regression',
     },
   ],
@@ -164,7 +164,7 @@ module.exports = {
     {
       tcid: 'PP-OOS-04',
       name: '@PP-OOS-AgentOrchestrator',
-      url: `${BUSINESS_STAGE_ORIGIN}/products/experience-platform/agent-orchestrator.html`,
+      url: `${BUSINESS_ORIGIN}/products/experience-platform/agent-orchestrator.html`,
       tags: '@bacom @progressive-profiling @pp @out-of-scope @multi-step @regression',
       multiStep: true,
       steps: 3,
@@ -172,7 +172,7 @@ module.exports = {
     {
       tcid: 'PP-OOS-05',
       name: '@PP-OOS-CreativeCloudBusiness',
-      url: `${BUSINESS_STAGE_ORIGIN}/products/creativecloud-business.html`,
+      url: `${BUSINESS_ORIGIN}/products/creativecloud-business.html`,
       tags: '@bacom @progressive-profiling @pp @out-of-scope @multi-step @regression',
       multiStep: true,
       steps: 3,

--- a/nala/blocks/progressive-profiling/progressive-profiling.spec.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.spec.js
@@ -1,0 +1,161 @@
+/**
+ * BACOM Progressive Profiling Feature Definitions
+ *
+ * Test Coverage:
+ * - Unknown user field visibility across all form types
+ * - Known user pre-fill and progressive field behavior
+ * - Form journeys: Short→Medium, Short→RFI, Medium→RFI
+ *
+ * Form Types:
+ * - Short (Essential DX): Basic fields (Email, Name, Company, Country)
+ * - Medium (Expanded DX): Basic + Job fields (JobTitle, FunctionalArea)
+ * - RFI (Contact/Full): All fields including contact details
+ *
+ * Browser/Platform Requirements (Non-Functional):
+ * - Chrome (Desktop) - Primary browser
+ * - Firefox (Desktop)
+ * - Safari/WebKit (Desktop)
+ *
+ * Email Requirement:
+ * - Use @adobetest.com emails (e.g., xiasun+test001@adobetest.com)
+ */
+
+module.exports = {
+  name: 'BACOM Progressive Profiling',
+  features: [
+    // =========================================================================
+    // UNKNOWN USER TESTS - Verify all fields are visible, no pre-fill
+    // =========================================================================
+    {
+      tcid: '0',
+      name: '@PP-Unknown-ShortForm-DX',
+      url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
+      description: 'Unknown user visits Short DX form - all Short fields visible, no pre-fill',
+      tags: '@bacom @progressive-profiling @unknown @short @dx @smoke @regression',
+      formType: 'short',
+      userState: 'unknown',
+    },
+    {
+      tcid: '1',
+      name: '@PP-Unknown-MediumForm-DX',
+      url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
+      description: 'Unknown user visits Medium DX form - all Medium fields visible, no pre-fill',
+      tags: '@bacom @progressive-profiling @unknown @medium @dx @smoke @regression',
+      formType: 'medium',
+      userState: 'unknown',
+    },
+    {
+      tcid: '2',
+      name: '@PP-Unknown-RFIForm',
+      url: 'https://business.adobe.com/resources/form-test-5-stage.html',
+      description: 'Unknown user visits RFI form - all RFI fields visible, no pre-fill',
+      tags: '@bacom @progressive-profiling @unknown @rfi @smoke @regression',
+      formType: 'rfi',
+      userState: 'unknown',
+    },
+
+    // =========================================================================
+    // JOURNEY TESTS - Short to Medium Form
+    // =========================================================================
+    {
+      tcid: '3',
+      name: '@PP-Journey-ShortToMedium',
+      description: 'User fills Short DX form, then visits Medium DX form - basic fields pre-filled',
+      tags: '@bacom @progressive-profiling @journey @short-to-medium @smoke @regression',
+      journey: {
+        firstForm: {
+          type: 'short',
+          url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
+        },
+        secondForm: {
+          type: 'medium',
+          url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
+        },
+      },
+    },
+
+    // =========================================================================
+    // JOURNEY TESTS - Short to RFI Form
+    // =========================================================================
+    {
+      tcid: '4',
+      name: '@PP-Journey-ShortToRFI',
+      description: 'User fills Short DX form, then visits RFI form - basic fields pre-filled',
+      tags: '@bacom @progressive-profiling @journey @short-to-rfi @smoke @regression',
+      journey: {
+        firstForm: {
+          type: 'short',
+          url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
+        },
+        secondForm: {
+          type: 'rfi',
+          url: 'https://business.adobe.com/resources/form-test-5-stage.html',
+        },
+      },
+    },
+
+    // =========================================================================
+    // JOURNEY TESTS - Medium to RFI Form
+    // =========================================================================
+    {
+      tcid: '5',
+      name: '@PP-Journey-MediumToRFI',
+      description: 'User fills Medium DX form, then visits RFI form',
+      tags: '@bacom @progressive-profiling @journey @medium-to-rfi @smoke @regression',
+      journey: {
+        firstForm: {
+          type: 'medium',
+          url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
+        },
+        secondForm: {
+          type: 'rfi',
+          url: 'https://business.adobe.com/resources/form-test-5-stage.html',
+        },
+      },
+    },
+
+    // =========================================================================
+    // FORM SUBMISSION TESTS - Verify form can be submitted successfully
+    // =========================================================================
+    {
+      tcid: '6',
+      name: '@PP-Submit-ShortForm',
+      description: 'Submit Short DX form and verify redirect to thank you page',
+      tags: '@bacom @progressive-profiling @submit @short @smoke @regression',
+      url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html',
+      formType: 'short',
+      testSubmission: true,
+    },
+    {
+      tcid: '7',
+      name: '@PP-Submit-MediumForm',
+      description: 'Submit Medium DX form and verify redirect to thank you page',
+      tags: '@bacom @progressive-profiling @submit @medium @smoke @regression',
+      url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
+      formType: 'medium',
+      testSubmission: true,
+    },
+    {
+      tcid: '8',
+      name: '@PP-Submit-RFIForm',
+      description: 'Submit RFI form and verify redirect to thank you page',
+      tags: '@bacom @progressive-profiling @submit @rfi @smoke @regression',
+      url: 'https://business.adobe.com/resources/form-test-5-stage.html',
+      formType: 'rfi',
+      testSubmission: true,
+    },
+
+    // =========================================================================
+    // EDGE CASE TESTS
+    // =========================================================================
+    {
+      tcid: '9',
+      name: '@PP-EdgeCase-ClearedCookies',
+      description: 'Verify form behaves as unknown user after cookies are cleared',
+      tags: '@bacom @progressive-profiling @edge-case @regression',
+      url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html',
+      formType: 'medium',
+      testCookieClear: true,
+    },
+  ],
+};

--- a/nala/blocks/progressive-profiling/progressive-profiling.test.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.test.js
@@ -1,45 +1,16 @@
 import { expect, test } from '@playwright/test';
-import { features } from './progressive-profiling.spec.js';
 import ProgressiveProfilingForm from './progressive-profiling.page.js';
 
-/**
- * BACOM Progressive Profiling Test Suite
- *
- * Tests progressive profiling rules for form field visibility and hiding behaviors
- * across Short DX, Medium DX, and RFI forms.
- *
- * =============================================================================
- * PROGRESSIVE PROFILING RULES
- * =============================================================================
- *
- * KEY RULE: When a user fills a form, previously collected fields become HIDDEN
- * on subsequent forms (not just pre-filled).
- *
- * Journey Rules:
- * - Short → Medium: FirstName, LastName, Company, Phone, PostalCode, State, POI = HIDDEN
- * - Short → RFI: FirstName, LastName, Company = HIDDEN
- * - Medium → RFI: FirstName, LastName, Company, JobTitle, Department = HIDDEN
- *
- * Email: xiasun+test001@adobetest.com (required @adobetest.com domain)
- */
+const PPSpec = require('./progressive-profiling.spec.js');
 
-let ppForm;
+const {
+  stagedPages,
+  journeyFlows,
+  ongoingPages,
+  outOfScopePages,
+} = PPSpec;
 
-const FIELD_RULES = {
-  short: {
-    visible: ['email', 'firstName', 'lastName', 'company', 'country'],
-    hidden: ['state', 'postalCode', 'phone', 'jobTitle', 'functionalArea', 'primaryProductInterest'],
-  },
-  medium: {
-    visible: ['email', 'firstName', 'lastName', 'company', 'country', 'jobTitle', 'functionalArea'],
-    hidden: ['state', 'postalCode', 'phone', 'primaryProductInterest'],
-  },
-  rfi: {
-    visible: ['email', 'firstName', 'lastName', 'company', 'country', 'phone', 'jobTitle', 'functionalArea', 'primaryProductInterest'],
-    visibleAfterCountry: ['state', 'postalCode'],
-    hidden: [],
-  },
-};
+const REVISIT_DELAY_MS = Number(process.env.PP_REVISIT_DELAY_MS || '60000');
 
 const TEST_USER = {
   email: 'xiasun+test001@adobetest.com',
@@ -55,402 +26,478 @@ const TEST_USER = {
   primaryProductInterest: 'Real-time web analytics',
 };
 
+const KNOWN_VISITOR_FIELDS = [
+  'email',
+  'firstName',
+  'lastName',
+  'company',
+  'country',
+  'jobTitle',
+  'functionalArea',
+  'phone',
+  'state',
+  'postalCode',
+  'primaryProductInterest',
+];
+
+const REQUEST_CONSULTATION_STEP_2_FIELDS = [
+  'firstName',
+  'lastName',
+  'email',
+  'phone',
+  'jobTitle',
+  'functionalArea',
+  'company',
+  'country',
+  'state',
+  'postalCode',
+  'primaryProductInterest',
+];
+
+const REQUEST_CONSULTATION_STEP_1_FIELDS = [
+  'firstName',
+  'lastName',
+  'email',
+  'company',
+  'country',
+];
+
+const REQUEST_CONSULTATION_STEP_3_FIELDS = [
+  'firstName',
+  'lastName',
+  'email',
+  'phone',
+  'jobTitle',
+  'functionalArea',
+  'company',
+  'country',
+  'state',
+  'postalCode',
+  'primaryProductInterest',
+];
+
+let ppForm;
+
+function getPageByFormType(formType) {
+  return stagedPages.find((page) => page.formType === formType);
+}
+
+function scenarioTag(baseTag, scenario) {
+  return `${baseTag}-${scenario}`;
+}
+
+async function fillFormByType(formType, userData) {
+  if (formType === 'short') {
+    await ppForm.fillShortForm(userData);
+    return;
+  }
+
+  if (formType === 'medium') {
+    await ppForm.fillMediumForm(userData);
+    return;
+  }
+
+  await ppForm.fillRfiForm(userData);
+}
+
+async function createKnownVisitor(sourcePage, userData = TEST_USER) {
+  await ppForm.clearUserState();
+  await ppForm.goto(sourcePage.url);
+  await fillFormByType(sourcePage.formType, userData);
+  const submitted = await ppForm.submitAndWaitForRedirect();
+  expect(submitted, `Expected ${sourcePage.url} to submit successfully`).toBe(true);
+}
+
+async function waitForRevisitPropagation() {
+  console.info(`[PP] Waiting ${REVISIT_DELAY_MS}ms before revisit validation`);
+  await ppForm.page.waitForTimeout(REVISIT_DELAY_MS);
+}
+
+async function getVisibleKnownFieldStates(fieldNames = KNOWN_VISITOR_FIELDS) {
+  const details = [];
+
+  for (const fieldName of fieldNames) {
+    const isVisible = await ppForm.isFieldVisible(fieldName);
+    if (isVisible) {
+      const isPrefilled = await ppForm.isFieldPrefilled(fieldName);
+      details.push({
+        field: fieldName,
+        state: isPrefilled ? 'prefilled' : 'empty',
+      });
+    }
+  }
+
+  return details;
+}
+
+async function getKnownFieldStates(fieldNames = KNOWN_VISITOR_FIELDS) {
+  const details = [];
+
+  for (const fieldName of fieldNames) {
+    const isVisible = await ppForm.isFieldVisible(fieldName);
+    const isPrefilled = isVisible ? await ppForm.isFieldPrefilled(fieldName) : false;
+    let state = 'visible-empty';
+
+    if (!isVisible) {
+      state = 'hidden';
+    } else if (isPrefilled) {
+      state = 'prefilled';
+    }
+
+    details.push({
+      field: fieldName,
+      state,
+    });
+  }
+
+  return details;
+}
+
+function compareKnownFieldStates(baselineDetails, revisitDetails) {
+  const baselineMap = new Map(baselineDetails.map((detail) => [detail.field, detail.state]));
+
+  const details = revisitDetails.map((detail) => {
+    const expected = baselineMap.get(detail.field) || 'hidden';
+    return {
+      field: detail.field,
+      expected,
+      actual: detail.state,
+      changed: expected !== detail.state,
+    };
+  });
+
+  return {
+    count: details.filter((detail) => detail.changed).length,
+    details,
+  };
+}
+
+async function expectVisibleKnownFieldsEmpty(pageUrl, stepLabel, fieldNames = KNOWN_VISITOR_FIELDS) {
+  const visibleFieldStates = await getVisibleKnownFieldStates(fieldNames);
+
+  visibleFieldStates.forEach((detail) => {
+    console.info(`[PP][${stepLabel}] ${detail.field}: ${detail.state}`);
+    expect(
+      detail.state,
+      `Expected ${detail.field} to stay empty on ${stepLabel} for ${pageUrl}`,
+    ).toBe('empty');
+  });
+}
+
+async function expectKnownFieldsVisible(pageUrl, stepLabel, fieldNames) {
+  for (const fieldName of fieldNames) {
+    expect(
+      await ppForm.isFieldVisible(fieldName),
+      `Expected ${fieldName} to remain visible on ${stepLabel} for ${pageUrl}`,
+    ).toBe(true);
+  }
+}
+
+function getMultistepKnownFieldsByStep(pageData) {
+  return pageData.knownFieldsByStep || {
+    1: REQUEST_CONSULTATION_STEP_1_FIELDS,
+    2: REQUEST_CONSULTATION_STEP_2_FIELDS,
+    3: REQUEST_CONSULTATION_STEP_3_FIELDS,
+  };
+}
+
+async function completeOutOfScopeMultistepFlow(pageData, options = {}) {
+  const {
+    validateFirstStep = false,
+    expectEmptyKnownFields = false,
+    expectedVisibleFieldsByStep = {},
+  } = options;
+
+  expect(
+    await ppForm.getCurrentStep(),
+    `Expected ${pageData.url} to start on step 1`,
+  ).toBe(1);
+
+  if (expectEmptyKnownFields) {
+    await expectVisibleKnownFieldsEmpty(pageData.url, 'Multistep Step 1');
+  }
+
+  if (validateFirstStep) {
+    await ppForm.clickNextStep();
+    expect(
+      await ppForm.hasAnyValidationErrors(),
+      `Expected step 1 validation on ${pageData.url}`,
+    ).toBe(true);
+  }
+
+  await ppForm.fillVisibleRequiredFields(TEST_USER);
+  await ppForm.clickNextStep();
+  await ppForm.waitForStepChange(1);
+
+  if (expectedVisibleFieldsByStep[2]?.length) {
+    await expectKnownFieldsVisible(pageData.url, 'Multistep Step 2', expectedVisibleFieldsByStep[2]);
+  }
+
+  if (expectEmptyKnownFields) {
+    await expectVisibleKnownFieldsEmpty(pageData.url, 'Multistep Step 2');
+  }
+
+  await ppForm.fillVisibleRequiredFields(TEST_USER);
+  await ppForm.clickNextStep();
+  await ppForm.waitForStepChange(2);
+
+  if (expectedVisibleFieldsByStep[3]?.length) {
+    await expectKnownFieldsVisible(pageData.url, 'Multistep Step 3', expectedVisibleFieldsByStep[3]);
+  }
+
+  if (expectEmptyKnownFields) {
+    await expectVisibleKnownFieldsEmpty(pageData.url, 'Multistep Step 3');
+  }
+
+  await ppForm.fillVisibleRequiredFields(TEST_USER);
+  expect(
+    await ppForm.submitAnyFormAndWaitForSuccess(),
+    `Expected multi-step flow to submit successfully on ${pageData.url}`,
+  ).toBe(true);
+}
+
+async function collectMultistepKnownVisitorEffects(pageData) {
+  const knownFieldsByStep = getMultistepKnownFieldsByStep(pageData);
+  const steps = [];
+  let totalEffects = 0;
+
+  const step1Effects = await ppForm.getKnownVisitorEffects(knownFieldsByStep[1] || REQUEST_CONSULTATION_STEP_1_FIELDS);
+  steps.push({ step: 1, ...step1Effects });
+  totalEffects += step1Effects.count;
+
+  await ppForm.fillVisibleRequiredFields(TEST_USER);
+  await ppForm.clickNextStep();
+  await ppForm.waitForStepChange(1);
+
+  const step2Effects = await ppForm.getKnownVisitorEffects(knownFieldsByStep[2] || REQUEST_CONSULTATION_STEP_2_FIELDS);
+  steps.push({ step: 2, ...step2Effects });
+  totalEffects += step2Effects.count;
+
+  await ppForm.fillVisibleRequiredFields(TEST_USER);
+  await ppForm.clickNextStep();
+  await ppForm.waitForStepChange(2);
+
+  const step3Effects = await ppForm.getKnownVisitorEffects(knownFieldsByStep[3] || REQUEST_CONSULTATION_STEP_3_FIELDS);
+  steps.push({ step: 3, ...step3Effects });
+  totalEffects += step3Effects.count;
+
+  return { count: totalEffects, steps };
+}
+
 test.describe('BACOM Progressive Profiling Test Suite', () => {
-  test.setTimeout(5 * 60 * 1000);
+  test.setTimeout(8 * 60 * 1000);
 
   test.beforeEach(async ({ page }) => {
     ppForm = new ProgressiveProfilingForm(page);
   });
 
-  // ===========================================================================
-  // UNKNOWN USER TESTS - Field Visibility
-  // ===========================================================================
-
-  test.describe('Unknown User - Field Visibility', () => {
-    test(`${features[0].tcid}: ${features[0].name}, ${features[0].tags}`, async ({ page }) => {
-      const testPage = features[0].url;
-      console.info(`[Test Page]: ${testPage}`);
-
-      await test.step('Step 1: Clear user state to simulate unknown user', async () => {
+  test.describe('Staged Pages - Unknown Visitor', () => {
+    stagedPages.forEach((pageData) => {
+      test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'Unknown')}, ${pageData.tags}`, async () => {
         await ppForm.clearUserState();
-      });
-
-      await test.step('Step 2: Navigate to Short DX form', async () => {
-        await page.goto(testPage);
-        await page.waitForLoadState('domcontentloaded');
+        await ppForm.goto(pageData.url);
         await ppForm.clearStorageOnPage();
-        await ppForm.waitForFormLoad();
-      });
 
-      await test.step('Step 3: Verify Short form fields are visible', async () => {
-        const rules = FIELD_RULES.short;
-        console.info('[PP] Expected visible fields: firstName, lastName, email, company, country');
+        const results = await ppForm.verifyFieldVisibility(
+          pageData.unknownVisitor.visible,
+          pageData.unknownVisitor.hidden || [],
+        );
 
-        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
-
-        console.info('[PP] Field visibility results:');
-        results.details.forEach((d) => {
-          console.info(`  ${d.field}: expected=${d.expected}, actual=${d.actual}, ${d.pass ? '✓' : '✗'}`);
+        results.details.forEach((detail) => {
+          console.info(`[PP][Unknown] ${detail.field}: expected=${detail.expected}, actual=${detail.actual}`);
         });
 
         expect(results.failed).toBe(0);
-      });
 
-      await test.step('Step 4: Verify no fields are pre-filled for unknown user', async () => {
-        for (const field of FIELD_RULES.short.visible) {
-          if (field !== 'country') {
-            const isPrefilled = await ppForm.isFieldPrefilled(field);
-            expect(isPrefilled).toBe(false);
+        if (pageData.unknownVisitor.visibleAfterCountry?.length) {
+          await ppForm.fillField('country', TEST_USER.country);
+          await ppForm.page.waitForTimeout(1000);
+
+          for (const fieldName of pageData.unknownVisitor.visibleAfterCountry) {
+            expect(await ppForm.isFieldVisible(fieldName), `${fieldName} should appear after selecting country`).toBe(true);
           }
         }
       });
     });
+  });
 
-    test(`${features[1].tcid}: ${features[1].name}, ${features[1].tags}`, async ({ page }) => {
-      const testPage = features[1].url;
-      console.info(`[Test Page]: ${testPage}`);
-
-      await test.step('Step 1: Clear user state', async () => {
+  test.describe('Staged Pages - Required Validation', () => {
+    stagedPages.forEach((pageData) => {
+      test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'Validation')}, ${pageData.tags}`, async () => {
         await ppForm.clearUserState();
-      });
+        await ppForm.goto(pageData.url);
 
-      await test.step('Step 2: Navigate to Medium DX form', async () => {
-        await page.goto(testPage);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.clearStorageOnPage();
-        await ppForm.waitForFormLoad();
-      });
-
-      await test.step('Step 3: Verify Medium form fields are visible', async () => {
-        const rules = FIELD_RULES.medium;
-        console.info('[PP] Expected visible fields: firstName, lastName, email, company, country, jobTitle, functionalArea');
-
-        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
-
-        console.info('[PP] Field visibility results:');
-        results.details.forEach((d) => {
-          console.info(`  ${d.field}: expected=${d.expected}, actual=${d.actual}, ${d.pass ? '✓' : '✗'}`);
-        });
-
-        expect(results.failed).toBe(0);
+        const hasValidationErrors = await ppForm.submitAndCheckValidationErrors();
+        expect(hasValidationErrors, `Expected required validation on ${pageData.url}`).toBe(true);
       });
     });
+  });
 
-    test(`${features[2].tcid}: ${features[2].name}, ${features[2].tags}`, async ({ page }) => {
-      const testPage = features[2].url;
-      console.info(`[Test Page]: ${testPage}`);
+  test.describe('Staged Pages - Revisit Prefill', () => {
+    stagedPages.forEach((pageData) => {
+      test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'Revisit')}, ${pageData.tags}`, async () => {
+        await createKnownVisitor(pageData);
+        await waitForRevisitPropagation();
 
-      await test.step('Step 1: Clear user state', async () => {
-        await ppForm.clearUserState();
+        await ppForm.goto(pageData.url);
+
+        await expect(async () => {
+          const results = await ppForm.verifyFieldPrefill(pageData.revisitPrefill, []);
+
+          results.details.forEach((detail) => {
+            console.info(`[PP][Revisit] ${detail.field}: expected=${detail.expected}, actual=${detail.actual}`);
+          });
+
+          expect(results.failed).toBe(0);
+        }).toPass({ timeout: 45000 });
       });
+    });
+  });
 
-      await test.step('Step 2: Navigate to RFI form', async () => {
-        await page.goto(testPage);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.clearStorageOnPage();
-        await ppForm.waitForFormLoad();
-      });
-
-      await test.step('Step 3: Verify RFI form fields are visible (before country selection)', async () => {
-        const rules = FIELD_RULES.rfi;
-        console.info('[PP] Expected visible fields (before country):');
-        console.info('     email, firstName, lastName, company, country, phone, jobTitle, functionalArea, POI');
-
-        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
-
-        console.info('[PP] Field visibility results:');
-        results.details.forEach((d) => {
-          console.info(`  ${d.field}: expected=${d.expected}, actual=${d.actual}, ${d.pass ? '✓' : '✗'}`);
+  test.describe('Manual Email Link Journeys', () => {
+    journeyFlows.forEach((flow) => {
+      test(`${flow.tcid}: ${flow.name}, ${flow.tags}`, async () => {
+        await createKnownVisitor({
+          url: flow.sourceUrl,
+          formType: flow.sourceFormType,
         });
 
-        expect(results.failed).toBe(0);
+        console.info('='.repeat(60));
+        console.info(`[MANUAL PP] Validation via email link for ${flow.name}`);
+        console.info(`1. Open the email for ${TEST_USER.email}`);
+        console.info(`2. Click the link to ${flow.destinationUrl}`);
+        console.info(`3. Validate hidden fields: ${flow.expectedHidden.join(', ')}`);
+        console.info(`4. Validate visible fields: ${flow.expectedVisible.join(', ')}`);
+        console.info('5. Resume in Playwright Inspector when done');
+        console.info('='.repeat(60));
+
+        await ppForm.page.pause();
+      });
+    });
+  });
+
+  test.describe('In-Scope Ongoing Pages', () => {
+    ongoingPages.forEach((pageData) => {
+      test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'Unknown')}, ${pageData.tags}`, async () => {
+        await ppForm.clearUserState();
+        await ppForm.goto(pageData.url);
+
+        const baseline = await ppForm.captureFormSignature(KNOWN_VISITOR_FIELDS);
+        expect(baseline.genericVisibleFieldCount, `Expected a visible form on ${pageData.url}`).toBeGreaterThan(0);
+
+        const visibleFieldStates = await getVisibleKnownFieldStates();
+        visibleFieldStates.forEach((detail) => {
+          console.info(`[PP][Ongoing Unknown] ${detail.field}: ${detail.state}`);
+          expect(detail.state, `${detail.field} should not be prefilled for an unknown visitor on ${pageData.url}`).toBe('empty');
+        });
       });
 
-      await test.step('Step 4: Select country and verify state/postalCode appear', async () => {
-        await ppForm.fillField('country', 'United States');
-        await page.waitForTimeout(1000);
+      test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'Validation')}, ${pageData.tags}`, async () => {
+        await ppForm.clearUserState();
+        await ppForm.goto(pageData.url);
 
-        console.info('[PP] Checking dependent fields after country selection:');
-        for (const field of FIELD_RULES.rfi.visibleAfterCountry) {
-          const isVisible = await ppForm.isFieldVisible(field);
-          console.info(`  ${field}: ${isVisible ? 'VISIBLE ✓' : 'HIDDEN ✗'}`);
-          expect(isVisible, `Field "${field}" should be VISIBLE after selecting country`).toBe(true);
+        if (pageData.multiStep) {
+          await ppForm.clickNextStep();
+          expect(await ppForm.hasAnyValidationErrors(), `Expected step 1 validation on ${pageData.url}`).toBe(true);
+          return;
         }
+
+        expect(await ppForm.submitAndCheckValidationErrors(), `Expected required validation on ${pageData.url}`).toBe(true);
       });
-    });
-  });
 
-  // ===========================================================================
-  // JOURNEY TESTS - Short to Medium
-  // ===========================================================================
-
-  test.describe('Journey: Short to Medium Form', () => {
-    test(`${features[3].tcid}: ${features[3].name}, ${features[3].tags}`, async ({ page }) => {
-      const { journey } = features[3];
-      const firstFormUrl = journey.firstForm.url;
-
-      console.info(`[Journey] First form (Short): ${firstFormUrl}`);
-      console.info(`[Journey] Second form (Medium): ${journey.secondForm.url}`);
-
-      await test.step('Step 1: Clear user state to start as unknown', async () => {
+      test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'Revisit')}, ${pageData.tags}`, async () => {
         await ppForm.clearUserState();
-      });
+        await ppForm.goto(pageData.url);
 
-      await test.step('Step 2: Fill and submit Short form', async () => {
-        await page.goto(firstFormUrl);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.waitForFormLoad();
+        if (pageData.multiStep) {
+          await completeOutOfScopeMultistepFlow(pageData, {
+            expectedVisibleFieldsByStep: getMultistepKnownFieldsByStep(pageData),
+          });
 
-        await ppForm.fillShortForm(TEST_USER);
+          await waitForRevisitPropagation();
+          await ppForm.goto(pageData.url);
+
+          const effects = await collectMultistepKnownVisitorEffects(pageData);
+          effects.steps.forEach((stepResult) => {
+            stepResult.details.forEach((detail) => {
+              console.info(`[PP][Ongoing Step ${stepResult.step}] ${detail.field}: ${detail.actual}`);
+            });
+          });
+
+          expect(effects.count, `Expected known visitor behavior somewhere in the multistep flow on ${pageData.url}`).toBeGreaterThan(0);
+          return;
+        }
+
+        await ppForm.fillVisibleFields(TEST_USER, KNOWN_VISITOR_FIELDS);
 
         const submitted = await ppForm.submitAndWaitForRedirect();
-        expect(submitted).toBe(true);
-        console.info('[Journey] Short form submitted successfully');
-      });
+        expect(submitted, `Expected ${pageData.url} to submit successfully before revisit validation`).toBe(true);
 
-      await test.step('Step 3: Click email verification link (MANUAL STEP)', async () => {
-        console.info('='.repeat(60));
-        console.info('[MANUAL STEP] Email Verification Required:');
-        console.info('1. Check your email for verification link');
-        console.info('2. Click the link (or paste it in the browser)');
-        console.info('3. The link will take you to the Medium form with progressive profiling');
-        console.info('4. Wait for the form to fully load');
-        console.info('');
-        console.info('[Short → Medium] Field Verification:');
-        console.info('  ✗ HIDDEN: firstName, lastName, company');
-        console.info('  ✓ VISIBLE: email, country, jobTitle, dept');
-        console.info('');
-        console.info('5. Resume the test in Playwright Inspector');
-        console.info('='.repeat(60));
-        await page.pause();
-      });
-    });
-  });
+        await waitForRevisitPropagation();
+        await ppForm.goto(pageData.url);
 
-  // ===========================================================================
-  // JOURNEY TESTS - Short to RFI
-  // ===========================================================================
-
-  test.describe('Journey: Short to RFI Form', () => {
-    test(`${features[4].tcid}: ${features[4].name}, ${features[4].tags}`, async ({ page }) => {
-      const { journey } = features[4];
-      const firstFormUrl = journey.firstForm.url;
-
-      console.info(`[Journey] First form (Short): ${firstFormUrl}`);
-      console.info(`[Journey] Second form (RFI): ${journey.secondForm.url}`);
-
-      await test.step('Step 1: Clear user state', async () => {
-        await ppForm.clearUserState();
-      });
-
-      await test.step('Step 2: Fill and submit Short form', async () => {
-        await page.goto(firstFormUrl);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.waitForFormLoad();
-        await ppForm.fillShortForm(TEST_USER);
-        const submitted = await ppForm.submitAndWaitForRedirect();
-        expect(submitted).toBe(true);
-      });
-
-      await test.step('Step 3: Click email verification link (MANUAL STEP)', async () => {
-        console.info('='.repeat(60));
-        console.info('[MANUAL STEP] Email Verification Required:');
-        console.info('1. Check your email for verification link');
-        console.info('2. Click the link (or paste it in the browser)');
-        console.info('3. The link will take you to the RFI form with progressive profiling');
-        console.info('4. Wait for the form to fully load');
-        console.info('');
-        console.info('[Short → RFI] Field Verification:');
-        console.info('  ✗ HIDDEN: firstName, lastName, company');
-        console.info('  ✓ VISIBLE: email, country, phone, state, postalCode, jobTitle, dept, POI');
-        console.info('');
-        console.info('5. Resume the test in Playwright Inspector');
-        console.info('='.repeat(60));
-        await page.pause();
-      });
-    });
-  });
-
-  // ===========================================================================
-  // JOURNEY TESTS - Medium to RFI
-  // ===========================================================================
-
-  test.describe('Journey: Medium to RFI Form', () => {
-    test(`${features[5].tcid}: ${features[5].name}, ${features[5].tags}`, async ({ page }) => {
-      const { journey } = features[5];
-      const firstFormUrl = journey.firstForm.url;
-
-      console.info(`[Journey] First form (Medium): ${firstFormUrl}`);
-      console.info(`[Journey] Second form (RFI): ${journey.secondForm.url}`);
-
-      await test.step('Step 1: Clear user state', async () => {
-        await ppForm.clearUserState();
-      });
-
-      await test.step('Step 2: Fill and submit Medium form', async () => {
-        await page.goto(firstFormUrl);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.waitForFormLoad();
-        await ppForm.fillMediumForm(TEST_USER);
-        const submitted = await ppForm.submitAndWaitForRedirect();
-        expect(submitted).toBe(true);
-      });
-
-      await test.step('Step 3: Click email verification link (MANUAL STEP)', async () => {
-        console.info('='.repeat(60));
-        console.info('[MANUAL STEP] Email Verification Required:');
-        console.info('1. Check your email for verification link');
-        console.info('2. Click the link (or paste it in the browser)');
-        console.info('3. The link will take you to the RFI form with progressive profiling');
-        console.info('4. Wait for the form to fully load');
-        console.info('');
-        console.info('[Medium → RFI] Field Verification:');
-        console.info('  ✗ HIDDEN: firstName, lastName, company, jobTitle, dept');
-        console.info('  ✓ VISIBLE: email, country, phone, state, postalCode, POI');
-        console.info('');
-        console.info('5. Resume the test in Playwright Inspector');
-        console.info('='.repeat(60));
-        await page.pause();
-      });
-    });
-  });
-
-  // ===========================================================================
-  // FORM SUBMISSION TESTS
-  // ===========================================================================
-
-  test.describe('Form Submission Tests', () => {
-    test(`${features[6].tcid}: ${features[6].name}, ${features[6].tags}`, async ({ page }) => {
-      const testPage = features[6].url;
-
-      await test.step('Step 1: Clear user state', async () => {
-        await ppForm.clearUserState();
-      });
-
-      await test.step('Step 2: Navigate to Short form', async () => {
-        await page.goto(testPage);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.waitForFormLoad();
-      });
-
-      await test.step('Step 3: Fill form with test data', async () => {
-        console.info('[PP] Filling Short form: email, firstName, lastName, company, country');
-        await ppForm.fillShortForm(TEST_USER);
-      });
-
-      await test.step('Step 4: Submit and verify redirect', async () => {
-        const submitted = await ppForm.submitAndWaitForRedirect();
-        expect(submitted).toBe(true);
-
-        const currentUrl = page.url();
-        expect(currentUrl).toContain('submissionid');
-        console.info(`[PP] Redirected to: ${currentUrl}`);
-      });
-    });
-
-    test(`${features[7].tcid}: ${features[7].name}, ${features[7].tags}`, async ({ page }) => {
-      const testPage = features[7].url;
-
-      await test.step('Step 1: Clear user state', async () => {
-        await ppForm.clearUserState();
-      });
-
-      await test.step('Step 2: Navigate to Medium form', async () => {
-        await page.goto(testPage);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.waitForFormLoad();
-      });
-
-      await test.step('Step 3: Fill form with test data', async () => {
-        console.info('[PP] Filling Medium form: email, firstName, lastName, company, country, jobTitle, functionalArea');
-        await ppForm.fillMediumForm(TEST_USER);
-      });
-
-      await test.step('Step 4: Submit and verify redirect', async () => {
-        const submitted = await ppForm.submitAndWaitForRedirect();
-        expect(submitted).toBe(true);
-
-        const currentUrl = page.url();
-        expect(currentUrl).toContain('submissionid');
-        console.info(`[PP] Redirected to: ${currentUrl}`);
-      });
-    });
-
-    test(`${features[8].tcid}: ${features[8].name}, ${features[8].tags}`, async ({ page }) => {
-      const testPage = features[8].url;
-
-      await test.step('Step 1: Clear user state', async () => {
-        await ppForm.clearUserState();
-      });
-
-      await test.step('Step 2: Navigate to RFI form', async () => {
-        await page.goto(testPage);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.waitForFormLoad();
-      });
-
-      await test.step('Step 3: Fill form with test data', async () => {
-        console.info('[PP] Filling RFI form: ALL fields');
-        await ppForm.fillRfiForm(TEST_USER);
-      });
-
-      await test.step('Step 4: Submit and verify redirect', async () => {
-        const submitted = await ppForm.submitAndWaitForRedirect();
-        expect(submitted).toBe(true);
-
-        const currentUrl = page.url();
-        expect(currentUrl).toContain('submissionid');
-        console.info(`[PP] Redirected to: ${currentUrl}`);
-      });
-    });
-  });
-
-  // ===========================================================================
-  // EDGE CASE TESTS
-  // ===========================================================================
-
-  test.describe('Edge Cases', () => {
-    test(`${features[9].tcid}: ${features[9].name}, ${features[9].tags}`, async ({ page }) => {
-      const testPage = features[9].url;
-
-      await test.step('Step 1: First, fill a form to become "known"', async () => {
-        await ppForm.clearUserState();
-        await page.goto('https://business.adobe.com/resources/form-test-1-essential-dx-stage.html');
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.waitForFormLoad();
-        await ppForm.fillShortForm(TEST_USER);
-        await ppForm.submitAndWaitForRedirect();
-      });
-
-      await test.step('Step 2: Clear cookies to simulate unknown user', async () => {
-        await ppForm.clearUserState();
-      });
-
-      await test.step('Step 3: Navigate to Medium form', async () => {
-        await page.goto(testPage);
-        await page.waitForLoadState('domcontentloaded');
-        await ppForm.clearStorageOnPage();
-        await ppForm.waitForFormLoad();
-      });
-
-      await test.step('Step 4: Verify all Medium fields are visible (unknown user behavior)', async () => {
-        const rules = FIELD_RULES.medium;
-        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
-
-        console.info('[PP] Field visibility after cookie clear (should be like unknown user):');
-        results.details.forEach((d) => {
-          console.info(`  ${d.field}: ${d.actual}, ${d.pass ? '✓' : '✗'}`);
+        const effects = await ppForm.getKnownVisitorEffects(KNOWN_VISITOR_FIELDS);
+        effects.details.forEach((detail) => {
+          console.info(`[PP][Ongoing] ${detail.field}: ${detail.actual}`);
         });
 
-        expect(results.failed).toBe(0);
+        expect(effects.count, `Expected known visitor behavior on ${pageData.url}`).toBeGreaterThan(0);
       });
+    });
+  });
 
-      await test.step('Step 5: Verify no pre-fill (behaves as unknown)', async () => {
-        for (const field of ['email', 'firstName', 'lastName', 'company']) {
-          const isPrefilled = await ppForm.isFieldPrefilled(field);
-          console.info(`[PP] ${field} prefilled after cookie clear: ${isPrefilled}`);
-          expect(isPrefilled, `Field "${field}" should NOT be pre-filled after cookie clear`).toBe(false);
-        }
+  test.describe('Out-of-Scope Regression', () => {
+    const seedPage = getPageByFormType('short');
+
+    outOfScopePages.forEach((pageData) => {
+      if (pageData.multiStep) {
+        test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'NoPPFlow')}, ${pageData.tags}`, async () => {
+          await ppForm.clearUserState();
+          await ppForm.goto(pageData.url, false);
+
+          await completeOutOfScopeMultistepFlow(pageData, {
+            validateFirstStep: true,
+            expectedVisibleFieldsByStep: pageData.knownFieldsByStep || {},
+          });
+
+          await createKnownVisitor(seedPage);
+          await waitForRevisitPropagation();
+
+          await ppForm.goto(pageData.url, false);
+
+          await completeOutOfScopeMultistepFlow(pageData, {
+            expectEmptyKnownFields: true,
+            expectedVisibleFieldsByStep: pageData.knownFieldsByStep || {},
+          });
+        });
+        return;
+      }
+
+      test(`${pageData.tcid}: ${scenarioTag(pageData.name, 'NoChange')}, ${pageData.tags}`, async () => {
+        await ppForm.clearUserState();
+        await ppForm.goto(pageData.url, false);
+
+        const baseline = await ppForm.captureFormSignature(KNOWN_VISITOR_FIELDS);
+        const baselineKnownFieldStates = await getKnownFieldStates(KNOWN_VISITOR_FIELDS);
+        expect(baseline.genericVisibleFieldCount, `Expected a visible form on ${pageData.url}`).toBeGreaterThan(0);
+        expect(await ppForm.submitAnyFormAndCheckValidationErrors(), `Expected ${pageData.url} to remain functionally valid on empty submit`).toBe(true);
+
+        await createKnownVisitor(seedPage);
+        await waitForRevisitPropagation();
+
+        await ppForm.goto(pageData.url, false);
+
+        const revisit = await ppForm.captureFormSignature(KNOWN_VISITOR_FIELDS);
+        const revisitKnownFieldStates = await getKnownFieldStates(KNOWN_VISITOR_FIELDS);
+        const effects = compareKnownFieldStates(baselineKnownFieldStates, revisitKnownFieldStates);
+
+        effects.details.forEach((detail) => {
+          console.info(`[PP][OutOfScope] ${detail.field}: expected=${detail.expected}, actual=${detail.actual}`);
+        });
+
+        expect(revisit.genericVisibleFieldCount).toBe(baseline.genericVisibleFieldCount);
+        expect(revisit.marketoVisibleFields).toEqual(baseline.marketoVisibleFields);
+        expect(effects.count, `Expected no known-field state changes on ${pageData.url}`).toBe(0);
       });
     });
   });

--- a/nala/blocks/progressive-profiling/progressive-profiling.test.js
+++ b/nala/blocks/progressive-profiling/progressive-profiling.test.js
@@ -1,0 +1,457 @@
+import { expect, test } from '@playwright/test';
+import { features } from './progressive-profiling.spec.js';
+import ProgressiveProfilingForm from './progressive-profiling.page.js';
+
+/**
+ * BACOM Progressive Profiling Test Suite
+ *
+ * Tests progressive profiling rules for form field visibility and hiding behaviors
+ * across Short DX, Medium DX, and RFI forms.
+ *
+ * =============================================================================
+ * PROGRESSIVE PROFILING RULES
+ * =============================================================================
+ *
+ * KEY RULE: When a user fills a form, previously collected fields become HIDDEN
+ * on subsequent forms (not just pre-filled).
+ *
+ * Journey Rules:
+ * - Short → Medium: FirstName, LastName, Company, Phone, PostalCode, State, POI = HIDDEN
+ * - Short → RFI: FirstName, LastName, Company = HIDDEN
+ * - Medium → RFI: FirstName, LastName, Company, JobTitle, Department = HIDDEN
+ *
+ * Email: xiasun+test001@adobetest.com (required @adobetest.com domain)
+ */
+
+let ppForm;
+
+const FIELD_RULES = {
+  short: {
+    visible: ['email', 'firstName', 'lastName', 'company', 'country'],
+    hidden: ['state', 'postalCode', 'phone', 'jobTitle', 'functionalArea', 'primaryProductInterest'],
+  },
+  medium: {
+    visible: ['email', 'firstName', 'lastName', 'company', 'country', 'jobTitle', 'functionalArea'],
+    hidden: ['state', 'postalCode', 'phone', 'primaryProductInterest'],
+  },
+  rfi: {
+    visible: ['email', 'firstName', 'lastName', 'company', 'country', 'phone', 'jobTitle', 'functionalArea', 'primaryProductInterest'],
+    visibleAfterCountry: ['state', 'postalCode'],
+    hidden: [],
+  },
+};
+
+const TEST_USER = {
+  email: 'xiasun+test001@adobetest.com',
+  firstName: 'NalaTest',
+  lastName: 'Progressive',
+  company: 'Adobe Nala Test Corp',
+  country: 'United States',
+  state: 'California',
+  postalCode: '95110',
+  phone: '408-555-9999',
+  jobTitle: 'Individual Contributor',
+  functionalArea: 'Marketing: General',
+  primaryProductInterest: 'Real-time web analytics',
+};
+
+test.describe('BACOM Progressive Profiling Test Suite', () => {
+  test.setTimeout(5 * 60 * 1000);
+
+  test.beforeEach(async ({ page }) => {
+    ppForm = new ProgressiveProfilingForm(page);
+  });
+
+  // ===========================================================================
+  // UNKNOWN USER TESTS - Field Visibility
+  // ===========================================================================
+
+  test.describe('Unknown User - Field Visibility', () => {
+    test(`${features[0].tcid}: ${features[0].name}, ${features[0].tags}`, async ({ page }) => {
+      const testPage = features[0].url;
+      console.info(`[Test Page]: ${testPage}`);
+
+      await test.step('Step 1: Clear user state to simulate unknown user', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Navigate to Short DX form', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.clearStorageOnPage();
+        await ppForm.waitForFormLoad();
+      });
+
+      await test.step('Step 3: Verify Short form fields are visible', async () => {
+        const rules = FIELD_RULES.short;
+        console.info('[PP] Expected visible fields: firstName, lastName, email, company, country');
+
+        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
+
+        console.info('[PP] Field visibility results:');
+        results.details.forEach((d) => {
+          console.info(`  ${d.field}: expected=${d.expected}, actual=${d.actual}, ${d.pass ? '✓' : '✗'}`);
+        });
+
+        expect(results.failed).toBe(0);
+      });
+
+      await test.step('Step 4: Verify no fields are pre-filled for unknown user', async () => {
+        for (const field of FIELD_RULES.short.visible) {
+          if (field !== 'country') {
+            const isPrefilled = await ppForm.isFieldPrefilled(field);
+            expect(isPrefilled).toBe(false);
+          }
+        }
+      });
+    });
+
+    test(`${features[1].tcid}: ${features[1].name}, ${features[1].tags}`, async ({ page }) => {
+      const testPage = features[1].url;
+      console.info(`[Test Page]: ${testPage}`);
+
+      await test.step('Step 1: Clear user state', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Navigate to Medium DX form', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.clearStorageOnPage();
+        await ppForm.waitForFormLoad();
+      });
+
+      await test.step('Step 3: Verify Medium form fields are visible', async () => {
+        const rules = FIELD_RULES.medium;
+        console.info('[PP] Expected visible fields: firstName, lastName, email, company, country, jobTitle, functionalArea');
+
+        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
+
+        console.info('[PP] Field visibility results:');
+        results.details.forEach((d) => {
+          console.info(`  ${d.field}: expected=${d.expected}, actual=${d.actual}, ${d.pass ? '✓' : '✗'}`);
+        });
+
+        expect(results.failed).toBe(0);
+      });
+    });
+
+    test(`${features[2].tcid}: ${features[2].name}, ${features[2].tags}`, async ({ page }) => {
+      const testPage = features[2].url;
+      console.info(`[Test Page]: ${testPage}`);
+
+      await test.step('Step 1: Clear user state', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Navigate to RFI form', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.clearStorageOnPage();
+        await ppForm.waitForFormLoad();
+      });
+
+      await test.step('Step 3: Verify RFI form fields are visible (before country selection)', async () => {
+        const rules = FIELD_RULES.rfi;
+        console.info('[PP] Expected visible fields (before country):');
+        console.info('     email, firstName, lastName, company, country, phone, jobTitle, functionalArea, POI');
+
+        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
+
+        console.info('[PP] Field visibility results:');
+        results.details.forEach((d) => {
+          console.info(`  ${d.field}: expected=${d.expected}, actual=${d.actual}, ${d.pass ? '✓' : '✗'}`);
+        });
+
+        expect(results.failed).toBe(0);
+      });
+
+      await test.step('Step 4: Select country and verify state/postalCode appear', async () => {
+        await ppForm.fillField('country', 'United States');
+        await page.waitForTimeout(1000);
+
+        console.info('[PP] Checking dependent fields after country selection:');
+        for (const field of FIELD_RULES.rfi.visibleAfterCountry) {
+          const isVisible = await ppForm.isFieldVisible(field);
+          console.info(`  ${field}: ${isVisible ? 'VISIBLE ✓' : 'HIDDEN ✗'}`);
+          expect(isVisible, `Field "${field}" should be VISIBLE after selecting country`).toBe(true);
+        }
+      });
+    });
+  });
+
+  // ===========================================================================
+  // JOURNEY TESTS - Short to Medium
+  // ===========================================================================
+
+  test.describe('Journey: Short to Medium Form', () => {
+    test(`${features[3].tcid}: ${features[3].name}, ${features[3].tags}`, async ({ page }) => {
+      const { journey } = features[3];
+      const firstFormUrl = journey.firstForm.url;
+
+      console.info(`[Journey] First form (Short): ${firstFormUrl}`);
+      console.info(`[Journey] Second form (Medium): ${journey.secondForm.url}`);
+
+      await test.step('Step 1: Clear user state to start as unknown', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Fill and submit Short form', async () => {
+        await page.goto(firstFormUrl);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.waitForFormLoad();
+
+        await ppForm.fillShortForm(TEST_USER);
+
+        const submitted = await ppForm.submitAndWaitForRedirect();
+        expect(submitted).toBe(true);
+        console.info('[Journey] Short form submitted successfully');
+      });
+
+      await test.step('Step 3: Click email verification link (MANUAL STEP)', async () => {
+        console.info('='.repeat(60));
+        console.info('[MANUAL STEP] Email Verification Required:');
+        console.info('1. Check your email for verification link');
+        console.info('2. Click the link (or paste it in the browser)');
+        console.info('3. The link will take you to the Medium form with progressive profiling');
+        console.info('4. Wait for the form to fully load');
+        console.info('');
+        console.info('[Short → Medium] Field Verification:');
+        console.info('  ✗ HIDDEN: firstName, lastName, company');
+        console.info('  ✓ VISIBLE: email, country, jobTitle, dept');
+        console.info('');
+        console.info('5. Resume the test in Playwright Inspector');
+        console.info('='.repeat(60));
+        await page.pause();
+      });
+    });
+  });
+
+  // ===========================================================================
+  // JOURNEY TESTS - Short to RFI
+  // ===========================================================================
+
+  test.describe('Journey: Short to RFI Form', () => {
+    test(`${features[4].tcid}: ${features[4].name}, ${features[4].tags}`, async ({ page }) => {
+      const { journey } = features[4];
+      const firstFormUrl = journey.firstForm.url;
+
+      console.info(`[Journey] First form (Short): ${firstFormUrl}`);
+      console.info(`[Journey] Second form (RFI): ${journey.secondForm.url}`);
+
+      await test.step('Step 1: Clear user state', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Fill and submit Short form', async () => {
+        await page.goto(firstFormUrl);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.waitForFormLoad();
+        await ppForm.fillShortForm(TEST_USER);
+        const submitted = await ppForm.submitAndWaitForRedirect();
+        expect(submitted).toBe(true);
+      });
+
+      await test.step('Step 3: Click email verification link (MANUAL STEP)', async () => {
+        console.info('='.repeat(60));
+        console.info('[MANUAL STEP] Email Verification Required:');
+        console.info('1. Check your email for verification link');
+        console.info('2. Click the link (or paste it in the browser)');
+        console.info('3. The link will take you to the RFI form with progressive profiling');
+        console.info('4. Wait for the form to fully load');
+        console.info('');
+        console.info('[Short → RFI] Field Verification:');
+        console.info('  ✗ HIDDEN: firstName, lastName, company');
+        console.info('  ✓ VISIBLE: email, country, phone, state, postalCode, jobTitle, dept, POI');
+        console.info('');
+        console.info('5. Resume the test in Playwright Inspector');
+        console.info('='.repeat(60));
+        await page.pause();
+      });
+    });
+  });
+
+  // ===========================================================================
+  // JOURNEY TESTS - Medium to RFI
+  // ===========================================================================
+
+  test.describe('Journey: Medium to RFI Form', () => {
+    test(`${features[5].tcid}: ${features[5].name}, ${features[5].tags}`, async ({ page }) => {
+      const { journey } = features[5];
+      const firstFormUrl = journey.firstForm.url;
+
+      console.info(`[Journey] First form (Medium): ${firstFormUrl}`);
+      console.info(`[Journey] Second form (RFI): ${journey.secondForm.url}`);
+
+      await test.step('Step 1: Clear user state', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Fill and submit Medium form', async () => {
+        await page.goto(firstFormUrl);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.waitForFormLoad();
+        await ppForm.fillMediumForm(TEST_USER);
+        const submitted = await ppForm.submitAndWaitForRedirect();
+        expect(submitted).toBe(true);
+      });
+
+      await test.step('Step 3: Click email verification link (MANUAL STEP)', async () => {
+        console.info('='.repeat(60));
+        console.info('[MANUAL STEP] Email Verification Required:');
+        console.info('1. Check your email for verification link');
+        console.info('2. Click the link (or paste it in the browser)');
+        console.info('3. The link will take you to the RFI form with progressive profiling');
+        console.info('4. Wait for the form to fully load');
+        console.info('');
+        console.info('[Medium → RFI] Field Verification:');
+        console.info('  ✗ HIDDEN: firstName, lastName, company, jobTitle, dept');
+        console.info('  ✓ VISIBLE: email, country, phone, state, postalCode, POI');
+        console.info('');
+        console.info('5. Resume the test in Playwright Inspector');
+        console.info('='.repeat(60));
+        await page.pause();
+      });
+    });
+  });
+
+  // ===========================================================================
+  // FORM SUBMISSION TESTS
+  // ===========================================================================
+
+  test.describe('Form Submission Tests', () => {
+    test(`${features[6].tcid}: ${features[6].name}, ${features[6].tags}`, async ({ page }) => {
+      const testPage = features[6].url;
+
+      await test.step('Step 1: Clear user state', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Navigate to Short form', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.waitForFormLoad();
+      });
+
+      await test.step('Step 3: Fill form with test data', async () => {
+        console.info('[PP] Filling Short form: email, firstName, lastName, company, country');
+        await ppForm.fillShortForm(TEST_USER);
+      });
+
+      await test.step('Step 4: Submit and verify redirect', async () => {
+        const submitted = await ppForm.submitAndWaitForRedirect();
+        expect(submitted).toBe(true);
+
+        const currentUrl = page.url();
+        expect(currentUrl).toContain('submissionid');
+        console.info(`[PP] Redirected to: ${currentUrl}`);
+      });
+    });
+
+    test(`${features[7].tcid}: ${features[7].name}, ${features[7].tags}`, async ({ page }) => {
+      const testPage = features[7].url;
+
+      await test.step('Step 1: Clear user state', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Navigate to Medium form', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.waitForFormLoad();
+      });
+
+      await test.step('Step 3: Fill form with test data', async () => {
+        console.info('[PP] Filling Medium form: email, firstName, lastName, company, country, jobTitle, functionalArea');
+        await ppForm.fillMediumForm(TEST_USER);
+      });
+
+      await test.step('Step 4: Submit and verify redirect', async () => {
+        const submitted = await ppForm.submitAndWaitForRedirect();
+        expect(submitted).toBe(true);
+
+        const currentUrl = page.url();
+        expect(currentUrl).toContain('submissionid');
+        console.info(`[PP] Redirected to: ${currentUrl}`);
+      });
+    });
+
+    test(`${features[8].tcid}: ${features[8].name}, ${features[8].tags}`, async ({ page }) => {
+      const testPage = features[8].url;
+
+      await test.step('Step 1: Clear user state', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 2: Navigate to RFI form', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.waitForFormLoad();
+      });
+
+      await test.step('Step 3: Fill form with test data', async () => {
+        console.info('[PP] Filling RFI form: ALL fields');
+        await ppForm.fillRfiForm(TEST_USER);
+      });
+
+      await test.step('Step 4: Submit and verify redirect', async () => {
+        const submitted = await ppForm.submitAndWaitForRedirect();
+        expect(submitted).toBe(true);
+
+        const currentUrl = page.url();
+        expect(currentUrl).toContain('submissionid');
+        console.info(`[PP] Redirected to: ${currentUrl}`);
+      });
+    });
+  });
+
+  // ===========================================================================
+  // EDGE CASE TESTS
+  // ===========================================================================
+
+  test.describe('Edge Cases', () => {
+    test(`${features[9].tcid}: ${features[9].name}, ${features[9].tags}`, async ({ page }) => {
+      const testPage = features[9].url;
+
+      await test.step('Step 1: First, fill a form to become "known"', async () => {
+        await ppForm.clearUserState();
+        await page.goto('https://business.adobe.com/resources/form-test-1-essential-dx-stage.html');
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.waitForFormLoad();
+        await ppForm.fillShortForm(TEST_USER);
+        await ppForm.submitAndWaitForRedirect();
+      });
+
+      await test.step('Step 2: Clear cookies to simulate unknown user', async () => {
+        await ppForm.clearUserState();
+      });
+
+      await test.step('Step 3: Navigate to Medium form', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await ppForm.clearStorageOnPage();
+        await ppForm.waitForFormLoad();
+      });
+
+      await test.step('Step 4: Verify all Medium fields are visible (unknown user behavior)', async () => {
+        const rules = FIELD_RULES.medium;
+        const results = await ppForm.verifyFieldVisibility(rules.visible, rules.hidden);
+
+        console.info('[PP] Field visibility after cookie clear (should be like unknown user):');
+        results.details.forEach((d) => {
+          console.info(`  ${d.field}: ${d.actual}, ${d.pass ? '✓' : '✗'}`);
+        });
+
+        expect(results.failed).toBe(0);
+      });
+
+      await test.step('Step 5: Verify no pre-fill (behaves as unknown)', async () => {
+        for (const field of ['email', 'firstName', 'lastName', 'company']) {
+          const isPrefilled = await ppForm.isFieldPrefilled(field);
+          console.info(`[PP] ${field} prefilled after cookie clear: ${isPrefilled}`);
+          expect(isPrefilled, `Field "${field}" should NOT be pre-filled after cookie clear`).toBe(false);
+        }
+      });
+    });
+  });
+});

--- a/nala/blocks/progressive-profiling/test-data.yml
+++ b/nala/blocks/progressive-profiling/test-data.yml
@@ -1,0 +1,154 @@
+---
+# =============================================================================
+# BACOM Progressive Profiling Test Data
+# Testing: Field visibility, pre-fill, and hiding behaviors across forms
+# Forms: Short DX (Essential), Medium DX (Expanded), RFI (Contact/Full)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Form URLs (DX forms only)
+# -----------------------------------------------------------------------------
+forms:
+  short-dx:
+    name: 'Short Form DX (Essential)'
+    url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+  medium-dx:
+    name: 'Medium Form DX (Expanded)'
+    url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+  rfi:
+    name: 'RFI Form (Contact/Full)'
+    url: 'https://business.adobe.com/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+
+# -----------------------------------------------------------------------------
+# Test User Data (using @adobetest.com emails as required)
+# -----------------------------------------------------------------------------
+testUsers:
+  default:
+    email: 'xiasun+test001@adobetest.com'
+    firstName: 'NalaTest'
+    lastName: 'UserPP'
+    company: 'Adobe Test Corp'
+    country: 'United States'
+    state: 'California'
+    postalCode: '95110'
+    phone: '408-555-0100'
+    jobTitle: 'Individual Contributor'
+    functionalArea: 'Marketing: General'
+    primaryProductInterest: 'Real-time web analytics'
+
+# -----------------------------------------------------------------------------
+# Field Visibility Rules by Form Type (Unknown User)
+# -----------------------------------------------------------------------------
+fieldRules:
+  # Short Form DX (Essential) - 5 fields
+  short-dx:
+    visible:
+      - email
+      - firstName
+      - lastName
+      - company
+      - country
+    hidden:
+      - state
+      - postalCode
+      - phone
+      - jobTitle
+      - functionalArea
+      - primaryProductInterest
+
+  # Medium Form DX (Expanded) - 7 fields
+  medium-dx:
+    visible:
+      - email
+      - firstName
+      - lastName
+      - company
+      - country
+      - jobTitle
+      - functionalArea
+    hidden:
+      - state
+      - postalCode
+      - phone
+      - primaryProductInterest
+
+  # RFI Form (Contact/Full) - 11 fields
+  # Note: state and postalCode are dependent on country selection
+  rfi:
+    visible:
+      - email
+      - firstName
+      - lastName
+      - company
+      - country
+      - phone
+      - jobTitle
+      - functionalArea
+      - primaryProductInterest
+    visibleAfterCountry:
+      - state
+      - postalCode
+    hidden: []
+
+# -----------------------------------------------------------------------------
+# Progressive Profiling Journey Rules
+# Previously collected fields should be HIDDEN on subsequent forms
+# -----------------------------------------------------------------------------
+journeyRules:
+  # Journey: Short DX → Medium DX
+  shortToMedium:
+    description: 'User filled Short form, now visiting Medium form via email link'
+    hidden:
+      - firstName
+      - lastName
+      - company
+    visible:
+      - email
+      - country
+      - jobTitle
+      - functionalArea
+
+  # Journey: Short DX → RFI
+  shortToRfi:
+    description: 'User filled Short form, now visiting RFI form via email link'
+    hidden:
+      - firstName
+      - lastName
+      - company
+    visible:
+      - email
+      - country
+      - phone
+      - state
+      - postalCode
+      - jobTitle
+      - functionalArea
+      - primaryProductInterest
+
+  # Journey: Medium DX → RFI
+  mediumToRfi:
+    description: 'User filled Medium form, now visiting RFI form via email link'
+    hidden:
+      - firstName
+      - lastName
+      - company
+      - jobTitle
+      - functionalArea
+    visible:
+      - email
+      - country
+      - phone
+      - state
+      - postalCode
+      - primaryProductInterest
+
+# -----------------------------------------------------------------------------
+# Thank You Page patterns (for form submission verification)
+# -----------------------------------------------------------------------------
+thankYouPatterns:
+  - 'submissionid'
+  - 'thank-you'
+  - 'form-test-thank-you'

--- a/nala/blocks/progressive-profiling/test-data.yml
+++ b/nala/blocks/progressive-profiling/test-data.yml
@@ -1,50 +1,243 @@
 ---
 # =============================================================================
 # BACOM Progressive Profiling Test Data
-# Testing: Field visibility, pre-fill, and hiding behaviors across forms
-# Forms: Short DX (Essential), Medium DX (Expanded), RFI (Contact/Full)
+# Source: Feature Deep Dive spec / PP deployment scope
+# Environment: business.stage.adobe.com for business pages
+# Validation modes:
+# - revisit: submit, wait ~1 minute, revisit page, validate prefilled values
+# - email-link: submit, open email, click link, validate progressive hide/show behavior
 # =============================================================================
 
-# -----------------------------------------------------------------------------
-# Form URLs (DX forms only)
-# -----------------------------------------------------------------------------
-forms:
-  short-dx:
-    name: 'Short Form DX (Essential)'
-    url: 'https://business.adobe.com/resources/form-test-1-essential-dx-stage.html'
+stagedTestPages:
+  - locale: 'US'
+    formType: 'short'
+    name: 'US Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/resources/form-test-1-essential-dx-stage.html'
     template: 'flex_content'
-  medium-dx:
-    name: 'Medium Form DX (Expanded)'
-    url: 'https://business.adobe.com/resources/form-test-2-expanded-dx-stage.html'
+    revisitValidation: 'prefill'
+  - locale: 'US'
+    formType: 'medium'
+    name: 'US Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/resources/form-test-2-expanded-dx-stage.html'
     template: 'flex_event'
-  rfi:
-    name: 'RFI Form (Contact/Full)'
-    url: 'https://business.adobe.com/resources/form-test-5-stage.html'
+    revisitValidation: 'prefill'
+  - locale: 'US'
+    formType: 'rfi'
+    name: 'US RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/resources/form-test-5-stage.html'
     template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'UK'
+    formType: 'short'
+    name: 'UK Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/uk/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'UK'
+    formType: 'medium'
+    name: 'UK Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/uk/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'UK'
+    formType: 'rfi'
+    name: 'UK RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/uk/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'AU'
+    formType: 'short'
+    name: 'AU Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/au/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'AU'
+    formType: 'medium'
+    name: 'AU Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/au/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'AU'
+    formType: 'rfi'
+    name: 'AU RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/au/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'JP'
+    formType: 'short'
+    name: 'JP Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/jp/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'JP'
+    formType: 'medium'
+    name: 'JP Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/jp/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'JP'
+    formType: 'rfi'
+    name: 'JP RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/jp/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'PT'
+    formType: 'short'
+    name: 'PT Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/pt/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'PT'
+    formType: 'medium'
+    name: 'PT Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/pt/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'PT'
+    formType: 'rfi'
+    name: 'PT RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/pt/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'KR'
+    formType: 'short'
+    name: 'KR Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/kr/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'KR'
+    formType: 'medium'
+    name: 'KR Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/kr/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'KR'
+    formType: 'rfi'
+    name: 'KR RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/kr/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'IT'
+    formType: 'short'
+    name: 'IT Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/it/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'IT'
+    formType: 'medium'
+    name: 'IT Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/it/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'IT'
+    formType: 'rfi'
+    name: 'IT RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/it/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'ES'
+    formType: 'short'
+    name: 'ES Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/es/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'ES'
+    formType: 'medium'
+    name: 'ES Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/es/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'ES'
+    formType: 'rfi'
+    name: 'ES RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/es/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'FR'
+    formType: 'short'
+    name: 'FR Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/fr/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'FR'
+    formType: 'medium'
+    name: 'FR Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/fr/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'FR'
+    formType: 'rfi'
+    name: 'FR RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/fr/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'DE'
+    formType: 'short'
+    name: 'DE Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/de/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'DE'
+    formType: 'medium'
+    name: 'DE Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/de/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'DE'
+    formType: 'rfi'
+    name: 'DE RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/de/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
+  - locale: 'IN'
+    formType: 'short'
+    name: 'IN Short Form DX (Essential)'
+    url: 'https://business.stage.adobe.com/in/resources/form-test-1-essential-dx-stage.html'
+    template: 'flex_content'
+    revisitValidation: 'prefill'
+  - locale: 'IN'
+    formType: 'medium'
+    name: 'IN Medium Form DX (Expanded)'
+    url: 'https://business.stage.adobe.com/in/resources/form-test-2-expanded-dx-stage.html'
+    template: 'flex_event'
+    revisitValidation: 'prefill'
+  - locale: 'IN'
+    formType: 'rfi'
+    name: 'IN RFI Form (Contact/Full)'
+    url: 'https://business.stage.adobe.com/in/resources/form-test-5-stage.html'
+    template: 'flex_contact'
+    revisitValidation: 'prefill'
 
-# -----------------------------------------------------------------------------
-# Test User Data (using @adobetest.com emails as required)
-# -----------------------------------------------------------------------------
+ongoingPages:
+  - 'https://business.stage.adobe.com/request-consultation.html'
+  - 'https://business.stage.adobe.com/au/request-consultation.html'
+  - 'https://business.stage.adobe.com/uk/request-consultation.html'
+  - 'https://business.stage.adobe.com/uk/resources/webinars/building-strong-it-foundations.html'
+  - 'https://business.stage.adobe.com/au/ai.html'
+
+outOfScopePages:
+  - 'https://www.stage.adobe.com/express/business/request-info'
+  - 'https://www.stage.adobe.com/acrobat/contact.html'
+  - 'https://www.stage.adobe.com/acrobat/business/developer-form.html'
+  - 'https://business.stage.adobe.com/products/experience-platform/agent-orchestrator.html'
+  - 'https://business.stage.adobe.com/products/creativecloud-business.html'
+
 testUsers:
   default:
     email: 'xiasun+test001@adobetest.com'
     firstName: 'NalaTest'
-    lastName: 'UserPP'
-    company: 'Adobe Test Corp'
+    lastName: 'Progressive'
+    company: 'Adobe Nala Test Corp'
     country: 'United States'
     state: 'California'
     postalCode: '95110'
-    phone: '408-555-0100'
+    phone: '408-555-9999'
     jobTitle: 'Individual Contributor'
     functionalArea: 'Marketing: General'
     primaryProductInterest: 'Real-time web analytics'
 
-# -----------------------------------------------------------------------------
-# Field Visibility Rules by Form Type (Unknown User)
-# -----------------------------------------------------------------------------
 fieldRules:
-  # Short Form DX (Essential) - 5 fields
-  short-dx:
+  short:
     visible:
       - email
       - firstName
@@ -58,9 +251,7 @@ fieldRules:
       - jobTitle
       - functionalArea
       - primaryProductInterest
-
-  # Medium Form DX (Expanded) - 7 fields
-  medium-dx:
+  medium:
     visible:
       - email
       - firstName
@@ -74,9 +265,6 @@ fieldRules:
       - postalCode
       - phone
       - primaryProductInterest
-
-  # RFI Form (Contact/Full) - 11 fields
-  # Note: state and postalCode are dependent on country selection
   rfi:
     visible:
       - email
@@ -93,14 +281,8 @@ fieldRules:
       - postalCode
     hidden: []
 
-# -----------------------------------------------------------------------------
-# Progressive Profiling Journey Rules
-# Previously collected fields should be HIDDEN on subsequent forms
-# -----------------------------------------------------------------------------
-journeyRules:
-  # Journey: Short DX → Medium DX
+emailLinkJourneys:
   shortToMedium:
-    description: 'User filled Short form, now visiting Medium form via email link'
     hidden:
       - firstName
       - lastName
@@ -110,10 +292,7 @@ journeyRules:
       - country
       - jobTitle
       - functionalArea
-
-  # Journey: Short DX → RFI
   shortToRfi:
-    description: 'User filled Short form, now visiting RFI form via email link'
     hidden:
       - firstName
       - lastName
@@ -127,10 +306,7 @@ journeyRules:
       - jobTitle
       - functionalArea
       - primaryProductInterest
-
-  # Journey: Medium DX → RFI
   mediumToRfi:
-    description: 'User filled Medium form, now visiting RFI form via email link'
     hidden:
       - firstName
       - lastName
@@ -145,10 +321,9 @@ journeyRules:
       - postalCode
       - primaryProductInterest
 
-# -----------------------------------------------------------------------------
-# Thank You Page patterns (for form submission verification)
-# -----------------------------------------------------------------------------
-thankYouPatterns:
-  - 'submissionid'
-  - 'thank-you'
-  - 'form-test-thank-you'
+acceptanceCriteria:
+  - 'Unknown visitor sees the full default field set for the configured template.'
+  - 'Known visitor values are prefilled on revisit after successful submission.'
+  - 'Required fields show inline validation errors on empty submit.'
+  - 'Successful submission redirects to the configured destination URL.'
+  - 'Out-of-scope pages remain visually and functionally unchanged.'

--- a/nala/utils/pr.run.sh
+++ b/nala/utils/pr.run.sh
@@ -2,7 +2,7 @@
 
 TAGS=""
 REPORTER=""
-EXCLUDE_PATTERN="nopr|lpb"
+EXCLUDE_PATTERN="nopr|lpb|pp"
 EXIT_STATUS=0
 
 echo "GITHUB_REF: $GITHUB_REF"


### PR DESCRIPTION
## Summary
- add Nala automation for progressive profiling staged, ongoing, journey, and out-of-scope coverage
- add a dedicated @pp tag across the PP suite for targeted manual runs
- exclude @pp tests from default PR Nala execution in nala/utils/pr.run.sh

## Testing
- git commit hook unit tests passed
- targeted progressive profiling Playwright coverage was run during validation