### PR TITLE
MWPW-190733 [Lingo Language Banner] Add onlybanner: true in Bacom config

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -151,6 +151,7 @@ const CONFIG = {
     mena_en: ['bh', 'dz', 'iq', 'ir', 'jo', 'lb', 'ly', 'om', 'ps', 'sy', 'tn', 'ye'],
   },
   lingoProjectSuccessLogging: 'on',
+  onlybanner: true,
 };
 
 const eagerLoad = (img) => {


### PR DESCRIPTION
We're working on - [MWPW-187779](https://jira.corp.adobe.com/browse/MWPW-187779). As part of this we need to add onlybanner:true config in BACOM. This can be added as code configuration or as metadata. Since BACOM is the only site which uses only language banner flow and we're introducing language modal flow for other sites - [Figma](https://www.figma.com/board/FXiKqVMffU0BRRHWzrl4ye/lingo-routing-acom-bacom-v1.4?node-id=0-1&p=f&t=dC2zyAqTPSvDfoTM-0). More details are in this [wiki](https://wiki.corp.adobe.com/pages/viewpage.action?pageId=3777767693&spaceKey=WEBT&title=Lingo%2BMarket%2BSelector%2B-%2BExpress).

Resolves: [MWPW-190733](https://jira.corp.adobe.com/browse/MWPW-190733)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://mwpw-190733-onlybanner--da-bacom--nishantka.aem.live/?martech=off

**QA:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off&milolibs=acommarketselector
- After: https://mwpw-190733-onlybanner--da-bacom--adobecom.aem.live/?martech=off&milolibs=acommarketselector
