### PR TITLE
LPB: Update Content-type <> Directory

### DIFF
--- a/nala/tools/landing-page-builder/cleanup-generated-pages.js
+++ b/nala/tools/landing-page-builder/cleanup-generated-pages.js
@@ -19,14 +19,14 @@ const PAGE_PREFIXES = [
 ];
 
 const REGIONS = ['', '/jp', '/kr', '/au'];
-const CONTENT_TYPES = ['guide', 'report', 'infographic', 'video-demo'];
+const CONTENT_DIRS = ['sdk', 'guides', 'reports', 'infographics', 'videos'];
 const EXECUTE = process.argv.includes('--execute');
 
 function getFolderPaths() {
   const folders = [];
   REGIONS.forEach((region) => {
-    CONTENT_TYPES.forEach((contentType) => {
-      folders.push(`${region}/resources/${contentType}`);
+    CONTENT_DIRS.forEach((dir) => {
+      folders.push(`${region}/resources/${dir}`);
     });
   });
   return folders;

--- a/nala/tools/landing-page-builder/landing-page-builder.spec.js
+++ b/nala/tools/landing-page-builder/landing-page-builder.spec.js
@@ -391,5 +391,113 @@ module.exports = {
         headline: 'Nala Infographic Toggle Ungated To Gated',
       },
     },
+
+    // =========================================================
+    // 3.4 Content Type Path Directory Mapping
+    // =========================================================
+    {
+      tcid: '29',
+      name: '@lpb-path-ungated-guide-sdk: Ungated Guide maps to /sdk/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @smoke @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Guide',
+        gated: 'Ungated',
+        region: 'US',
+        headline: 'Nala Path Ungated Guide',
+        expectedDir: '/resources/sdk/',
+      },
+    },
+    {
+      tcid: '30',
+      name: '@lpb-path-ungated-report-sdk: Ungated Report maps to /sdk/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Report',
+        gated: 'Ungated',
+        region: 'US',
+        headline: 'Nala Path Ungated Report',
+        expectedDir: '/resources/sdk/',
+      },
+    },
+    {
+      tcid: '31',
+      name: '@lpb-path-ungated-infographic-sdk: Ungated Infographic maps to /sdk/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Infographic',
+        gated: 'Ungated',
+        region: 'US',
+        headline: 'Nala Path Ungated Infographic',
+        expectedDir: '/resources/sdk/',
+      },
+    },
+    {
+      tcid: '32',
+      name: '@lpb-path-gated-guide-guides: Gated Guide maps to /guides/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Guide',
+        gated: 'Gated',
+        region: 'US',
+        headline: 'Nala Path Gated Guide',
+        expectedDir: '/resources/guides/',
+      },
+    },
+    {
+      tcid: '33',
+      name: '@lpb-path-gated-infographic-infographics: Gated Infographic maps to /infographics/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Infographic',
+        gated: 'Gated',
+        region: 'US',
+        headline: 'Nala Path Gated Infographic',
+        expectedDir: '/resources/infographics/',
+      },
+    },
+    {
+      tcid: '34',
+      name: '@lpb-path-gated-report-reports: Gated Report maps to /reports/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Report',
+        gated: 'Gated',
+        region: 'US',
+        headline: 'Nala Path Gated Report',
+        expectedDir: '/resources/reports/',
+      },
+    },
+    {
+      tcid: '35',
+      name: '@lpb-path-gated-video-videos: Gated Video/Demo maps to /videos/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Video/Demo',
+        gated: 'Gated',
+        region: 'US',
+        headline: 'Nala Path Gated Video',
+        expectedDir: '/resources/videos/',
+      },
+    },
+    {
+      tcid: '36',
+      name: '@lpb-path-ungated-video-videos: Ungated Video/Demo maps to /videos/ directory',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
+      data: {
+        contentType: 'Video/Demo',
+        gated: 'Ungated',
+        region: 'US',
+        headline: 'Nala Path Ungated Video',
+        expectedDir: '/resources/videos/',
+      },
+    },
   ],
 };

--- a/nala/tools/landing-page-builder/landing-page-builder.test.js
+++ b/nala/tools/landing-page-builder/landing-page-builder.test.js
@@ -89,8 +89,7 @@ test.describe('Landing Page Builder - Form & Field Tests', () => {
     await test.step('Verify path input is populated with correct prefix', async () => {
       const prefix = lpb.iframe.locator('.path-input-container .path-prefix');
       const prefixText = await prefix.textContent();
-      expect(prefixText).toContain('resources');
-      expect(prefixText.toLowerCase()).toContain(data.contentType.toLowerCase());
+      expect(prefixText).toContain('/resources/guides/');
     });
 
     await test.step('Verify page name placeholder is auto-generated from headline', async () => {
@@ -737,6 +736,33 @@ test.describe('Landing Page Builder - Form & Field Tests', () => {
       await lpb.clickSaveAndPreview();
       await lpb.waitForToast('Please complete all required fields', 'error');
       await expect(lpb.marqueeImageError).toBeVisible();
+    });
+  });
+
+  // =============================================================
+  // 3.4 Content Type Path Directory Mapping
+  // =============================================================
+
+  [29, 30, 31, 32, 33, 34, 35, 36].forEach((featureIndex) => {
+    test(`${features[featureIndex].name}, ${features[featureIndex].tags}`, async () => {
+      const { data } = features[featureIndex];
+
+      await test.step('Navigate to LPB with fresh state', async () => {
+        await lpb.navigateFresh(LPB_REF);
+      });
+
+      await test.step('Fill core options', async () => {
+        await lpb.selectContentType(data.contentType);
+        await lpb.selectGated(data.gated);
+        await lpb.selectRegion(data.region);
+        await lpb.fillMarqueeHeadline(data.headline);
+      });
+
+      await test.step(`Verify path prefix contains ${data.expectedDir}`, async () => {
+        const prefix = lpb.iframe.locator('.path-input-container .path-prefix');
+        const prefixText = await prefix.textContent();
+        expect(prefixText).toContain(data.expectedDir);
+      });
     });
   });
 });

--- a/test/tools/generator/landing-page.test.html
+++ b/test/tools/generator/landing-page.test.html
@@ -200,7 +200,7 @@
 
           const updatedPathInput = shadowRoot.querySelector('path-input');
           expect(updatedPathInput.disabled).to.be.false;
-          expect(updatedPathInput.prefix).to.include('/resources/guide/');
+          expect(updatedPathInput.prefix).to.include('/resources/sdk/');
 
           setPageName();
           await tick(100);
@@ -213,13 +213,43 @@
           expect(marqueeSection).to.exist;
         });
 
+        it('maps content type and gated status to correct path directory', async () => {
+          const cases = [
+            { contentType: 'Guide', gated: 'Ungated', expected: '/resources/sdk/' },
+            { contentType: 'Infographic', gated: 'Ungated', expected: '/resources/sdk/' },
+            { contentType: 'Report', gated: 'Ungated', expected: '/resources/sdk/' },
+            { contentType: 'Guide', gated: 'Gated', expected: '/resources/guides/' },
+            { contentType: 'Infographic', gated: 'Gated', expected: '/resources/infographics/' },
+            { contentType: 'Report', gated: 'Gated', expected: '/resources/reports/' },
+            { contentType: 'Video/Demo', gated: 'Gated', expected: '/resources/videos/' },
+            { contentType: 'Video/Demo', gated: 'Ungated', expected: '/resources/videos/' },
+          ];
+
+          for (const { contentType, gated, expected } of cases) {
+            generator.resetForm();
+            await tick(100);
+
+            setValue('contentType', contentType);
+            setValue('gated', gated);
+            setValue('region', '/');
+            setValue('marqueeHeadline', 'Test');
+            await tick(100);
+
+            const pathInput = shadowRoot.querySelector('path-input');
+            expect(pathInput.prefix).to.include(
+              expected,
+              `${contentType} + ${gated} should map to ${expected}, got ${pathInput.prefix}`
+            );
+          }
+        });
+
         it('completes all fields and submits successfully', async () => {
           fillCoreFields();
           await tick(100);
           setPageName();
           await tick(100);
 
-          expect(generator.form.url).to.equal('/resources/guide/test-page.html');
+          expect(generator.form.url).to.equal('/resources/sdk/test-page.html');
           expect(generator.form.pageName).to.equal('test-page');
 
           shadowRoot.querySelector('sl-button.confirm').click();
@@ -247,7 +277,7 @@
           for (let i = 0; i < 50; i++) {
             await tick(100);
             previewCall = daFetch.getCalls().find(
-              (call) => call.args[0].includes('/resources/guide/test-page') && call.args[1]?.method === 'POST'
+              (call) => call.args[0].includes('/resources/sdk/test-page') && call.args[1]?.method === 'POST'
             );
             if (previewCall) break;
           }

--- a/test/tools/generator/mocks/da-fetch.js
+++ b/test/tools/generator/mocks/da-fetch.js
@@ -110,7 +110,7 @@ daFetch.callsFake(async (url, options = {}) => {
   if (url.includes('admin.hlx.page') && url.includes('/preview/') && method === 'POST') {
     return {
       ok: true,
-      json: async () => ({ preview: { status: 200, url: 'https://main--da-bacom--adobecom.aem.page/resources/guide/test-page' } }),
+      json: async () => ({ preview: { status: 200, url: 'https://main--da-bacom--adobecom.aem.page/resources/sdk/test-page' } }),
     };
   }
 

--- a/tools/generator/form-sections.js
+++ b/tools/generator/form-sections.js
@@ -40,10 +40,17 @@ function optionsSelect(form, handleInput, optionName, optionLabel, options, hasE
 
 export function renderContentType(form, handleInput, regionOptions, { isLocked = false, hasError = () => '', onValidateRequest, onStatusChange } = {}) {
   const getPathPrefix = () => {
-    if (!form.region || !form.contentType) return '';
+    if (!form.region || !form.contentType || !form.gated) return '';
     const region = form.region.replace(/\/$/, '');
-    const contentType = form.contentType.toLowerCase().replace('/', '-');
-    return `${region}/resources/${contentType}/`;
+    const type = form.contentType.toLowerCase();
+    const isGated = form.gated === 'Gated';
+    const DIR_MAP = {
+      'video/demo': 'videos',
+      guide: isGated ? 'guides' : 'sdk',
+      infographic: isGated ? 'infographics' : 'sdk',
+      report: isGated ? 'reports' : 'sdk',
+    };
+    return `${region}/resources/${DIR_MAP[type] || type}/`;
   };
 
   const pathPrefix = getPathPrefix();


### PR DESCRIPTION
**Add your specific features or fixes**:
* Updated getPathPrefix in form-sections.js to derive the page directory from both content type and gated status instead of content type alone
* Ungated guides, infographics, and reports now route to /sdk/ instead of their individual content type directories
* Gated guides route to /guides/
* Gated infographics route to /infographics/
* Gated reports route to /reports/
* Gated and ungated video/demo content routes to /videos/
* Added !form.gated guard to getPathPrefix so no prefix is generated until gated status is selected
* Added a parameterized test covering all 8 content type + gated/ungated combinations
* Updated 3 existing test assertions and 1 mock URL to reflect the new Guide + Ungated → /sdk/ mapping

Resolves: [MWPW-191069](https://jira.corp.adobe.com/browse/MWPW-191069)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://lpb-update-content-type--da-bacom--adobecom.aem.live/?martech=off

**DA Test URLs**:
- Before: https://da.live/app/adobecom/da-bacom/tools/generator/landing-page
- After: https://da.live/app/adobecom/da-bacom/tools/generator/landing-page?ref=lpb-update-content-type
