### PR TITLE
LPB: Include ability to add headline in reports template

### DIFF
--- a/nala/tools/landing-page-builder/landing-page-builder.page.js
+++ b/nala/tools/landing-page-builder/landing-page-builder.page.js
@@ -80,6 +80,8 @@ export default class LandingPageBuilder {
     this.experienceFragment = root.locator('sl-select[name="experienceFragment"]');
 
     // Asset delivery
+    this.assetDeliverySection = root.locator('.form-row').filter({ has: root.locator('h2', { hasText: 'Asset Delivery' }) });
+    this.assetHeadline = root.locator('sl-input[name="assetHeadline"]');
     this.videoAsset = root.locator('sl-input[name="videoAsset"]');
     this.pdfFileInput = root.locator('input.pdf-file-input');
     this.pdfFileInfo = root.locator('.file-info');
@@ -380,6 +382,12 @@ export default class LandingPageBuilder {
   }
 
   // --- Asset Delivery ---
+
+  async fillAssetHeadline(text) {
+    const input = this.assetHeadline.locator('input');
+    await input.fill(text);
+    await input.dispatchEvent('input');
+  }
 
   async fillVideoUrl(url) {
     const input = this.videoAsset.locator('input');

--- a/nala/tools/landing-page-builder/landing-page-builder.spec.js
+++ b/nala/tools/landing-page-builder/landing-page-builder.spec.js
@@ -393,10 +393,62 @@ module.exports = {
     },
 
     // =========================================================
-    // 3.4 Content Type Path Directory Mapping
+    // 2.2 Asset Headline — Gated non-video content types
     // =========================================================
     {
       tcid: '29',
+      name: '@lpb-asset-headline-gated-report-visible: Gated Report shows Asset Headline field in Asset Delivery',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @smoke @asset-headline @gated @regression @bacom',
+      data: {
+        contentType: 'Report',
+        gated: 'Gated',
+        region: 'US',
+        headline: 'Nala Asset Headline Gated Report',
+      },
+    },
+    {
+      tcid: '30',
+      name: '@lpb-asset-headline-ungated-guide-hidden: Ungated Guide hides Asset Headline field',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @asset-headline @ungated @regression @bacom',
+      data: {
+        contentType: 'Guide',
+        gated: 'Ungated',
+        region: 'US',
+        headline: 'Nala Asset Headline Ungated Guide',
+      },
+    },
+    {
+      tcid: '31',
+      name: '@lpb-asset-headline-gated-video-hidden: Gated Video/Demo hides Asset Headline field',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @asset-headline @gated @content-type @regression @bacom',
+      data: {
+        contentType: 'Video/Demo',
+        gated: 'Gated',
+        region: 'US',
+        headline: 'Nala Asset Headline Gated Video',
+      },
+    },
+    {
+      tcid: '32',
+      name: '@lpb-asset-headline-toggle-gated-to-ungated: Switching Gated Report to Ungated hides Asset Headline without reload',
+      path: '/tools/generator/landing-page',
+      tags: '@lpb @lpb-non-e2e @asset-headline @gated @ungated @regression @bacom',
+      data: {
+        contentType: 'Report',
+        gated: 'Gated',
+        region: 'US',
+        headline: 'Nala Asset Headline Toggle',
+      },
+    },
+
+    // =========================================================
+    // 3.4 Content Type Path Directory Mapping
+    // =========================================================
+    {
+      tcid: '33',
       name: '@lpb-path-ungated-guide-sdk: Ungated Guide maps to /sdk/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @smoke @path-mapping @regression @bacom',
@@ -409,7 +461,7 @@ module.exports = {
       },
     },
     {
-      tcid: '30',
+      tcid: '34',
       name: '@lpb-path-ungated-report-sdk: Ungated Report maps to /sdk/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
@@ -422,7 +474,7 @@ module.exports = {
       },
     },
     {
-      tcid: '31',
+      tcid: '35',
       name: '@lpb-path-ungated-infographic-sdk: Ungated Infographic maps to /sdk/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
@@ -435,7 +487,7 @@ module.exports = {
       },
     },
     {
-      tcid: '32',
+      tcid: '36',
       name: '@lpb-path-gated-guide-guides: Gated Guide maps to /guides/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
@@ -448,7 +500,7 @@ module.exports = {
       },
     },
     {
-      tcid: '33',
+      tcid: '37',
       name: '@lpb-path-gated-infographic-infographics: Gated Infographic maps to /infographics/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
@@ -461,7 +513,7 @@ module.exports = {
       },
     },
     {
-      tcid: '34',
+      tcid: '38',
       name: '@lpb-path-gated-report-reports: Gated Report maps to /reports/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
@@ -474,7 +526,7 @@ module.exports = {
       },
     },
     {
-      tcid: '35',
+      tcid: '39',
       name: '@lpb-path-gated-video-videos: Gated Video/Demo maps to /videos/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',
@@ -487,7 +539,7 @@ module.exports = {
       },
     },
     {
-      tcid: '36',
+      tcid: '40',
       name: '@lpb-path-ungated-video-videos: Ungated Video/Demo maps to /videos/ directory',
       path: '/tools/generator/landing-page',
       tags: '@lpb @lpb-non-e2e @path-mapping @regression @bacom',

--- a/nala/tools/landing-page-builder/landing-page-builder.test.js
+++ b/nala/tools/landing-page-builder/landing-page-builder.test.js
@@ -740,10 +740,90 @@ test.describe('Landing Page Builder - Form & Field Tests', () => {
   });
 
   // =============================================================
+  // 2.2 Asset Headline — Gated non-video content types
+  // =============================================================
+
+  test(`${features[29].name}, ${features[29].tags}`, async () => {
+    const { data } = features[29];
+
+    await test.step('Navigate, fill core options as Gated Report, and confirm', async () => {
+      await lpb.navigateFresh(LPB_REF);
+      await lpb.fillCoreOptionsAndConfirm(data);
+    });
+
+    await test.step('Verify Asset Delivery section is visible', async () => {
+      const headers = await lpb.getVisibleSectionHeaders();
+      expect(headers).toContain('Asset Delivery');
+    });
+
+    await test.step('Verify Asset Headline input is visible with correct label', async () => {
+      await expect(lpb.assetHeadline).toBeVisible();
+      const label = await lpb.assetHeadline.getAttribute('label');
+      expect(label).toBe('Asset Headline');
+    });
+
+    await test.step('Verify Asset Headline input sits within the Asset Delivery section', async () => {
+      const scoped = lpb.assetDeliverySection.locator('sl-input[name="assetHeadline"]');
+      await expect(scoped).toBeVisible();
+    });
+  });
+
+  test(`${features[30].name}, ${features[30].tags}`, async () => {
+    const { data } = features[30];
+
+    await test.step('Navigate, fill core options as Ungated Guide, and confirm', async () => {
+      await lpb.navigateFresh(LPB_REF);
+      await lpb.fillCoreOptionsAndConfirm(data);
+    });
+
+    await test.step('Verify Asset Headline input is NOT visible', async () => {
+      await expect(lpb.assetHeadline).not.toBeVisible();
+    });
+  });
+
+  test(`${features[31].name}, ${features[31].tags}`, async () => {
+    const { data } = features[31];
+
+    await test.step('Navigate, fill core options as Gated Video/Demo, and confirm', async () => {
+      await lpb.navigateFresh(LPB_REF);
+      await lpb.fillCoreOptionsAndConfirm(data);
+    });
+
+    await test.step('Verify Video Asset input is visible (video branch of Asset Delivery)', async () => {
+      await expect(lpb.videoAsset).toBeVisible();
+    });
+
+    await test.step('Verify Asset Headline input is NOT visible for Video/Demo', async () => {
+      await expect(lpb.assetHeadline).not.toBeVisible();
+    });
+  });
+
+  test(`${features[32].name}, ${features[32].tags}`, async () => {
+    const { data } = features[32];
+
+    await test.step('Navigate, fill core options as Gated Report, and confirm', async () => {
+      await lpb.navigateFresh(LPB_REF);
+      await lpb.fillCoreOptionsAndConfirm(data);
+    });
+
+    await test.step('Verify Asset Headline input is initially visible', async () => {
+      await expect(lpb.assetHeadline).toBeVisible();
+    });
+
+    await test.step('Switch gating to Ungated without reloading', async () => {
+      await lpb.selectGated('Ungated');
+    });
+
+    await test.step('Verify Asset Headline input is no longer visible', async () => {
+      await expect(lpb.assetHeadline).not.toBeVisible();
+    });
+  });
+
+  // =============================================================
   // 3.4 Content Type Path Directory Mapping
   // =============================================================
 
-  [29, 30, 31, 32, 33, 34, 35, 36].forEach((featureIndex) => {
+  [33, 34, 35, 36, 37, 38, 39, 40].forEach((featureIndex) => {
     test(`${features[featureIndex].name}, ${features[featureIndex].tags}`, async () => {
       const { data } = features[featureIndex];
 

--- a/test/tools/generator/generator.test.js
+++ b/test/tools/generator/generator.test.js
@@ -56,4 +56,24 @@ describe('Generator', () => {
     const remainingFields = result.match(/{{[^}]+}}/g) || [];
     expect(remainingFields).to.deep.equal([]);
   });
+
+  it('replaces asset-headline placeholder with provided h2 content', () => {
+    const template = '<div>{{asset-headline}}<p>{{pdf-asset}}</p></div>';
+    const result = applyTemplateData(template, {
+      assetHeadline: '<h2>Digital Trends Report</h2>',
+      pdfAsset: '/path/to/pdf',
+    });
+    expect(result).to.include('<h2>Digital Trends Report</h2>');
+    expect(result).to.not.include('{{asset-headline}}');
+  });
+
+  it('removes asset-headline placeholder when value is empty', () => {
+    const template = '<div>{{asset-headline}}<p>{{pdf-asset}}</p></div>';
+    const result = applyTemplateData(template, {
+      assetHeadline: '',
+      pdfAsset: '/path/to/pdf',
+    });
+    expect(result).to.not.include('{{asset-headline}}');
+    expect(result).to.not.include('<h2>');
+  });
 });

--- a/test/tools/generator/generator.test.js
+++ b/test/tools/generator/generator.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved */
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
-import { applyTemplateData } from '../../../tools/generator/generator.js';
+import { applyTemplateData, injectAssetHeadlineIfMissing } from '../../../tools/generator/generator.js';
 import { LIBS } from '../../../scripts/scripts.js';
 
 const { loadArea } = await import(`${LIBS}/utils/utils.js`);
@@ -75,5 +75,27 @@ describe('Generator', () => {
     });
     expect(result).to.not.include('{{asset-headline}}');
     expect(result).to.not.include('<h2>');
+  });
+
+  it('injectAssetHeadlineIfMissing adds h2 before PDF link when template has no placeholder', () => {
+    const template = '<div class="form-success"><p>{{pdf-asset}}</p></div>';
+    const pdfUrl = 'https://main--da-bacom--adobecom.aem.page/resources/reports/file.pdf';
+    const applied = applyTemplateData(template, { pdfAsset: pdfUrl, pdfAssetName: 'file.pdf' });
+    const headline = '<h2>Industry outlook</h2>';
+    const out = injectAssetHeadlineIfMissing(template, applied, headline, pdfUrl);
+    expect(out).to.include(headline);
+    expect(out.indexOf(headline)).to.be.lessThan(out.indexOf('<a href='));
+  });
+
+  it('injectAssetHeadlineIfMissing is a no-op when template includes asset-headline placeholder', () => {
+    const template = '<div>{{asset-headline}}<p>{{pdf-asset}}</p></div>';
+    const pdfUrl = 'https://example.com/doc.pdf';
+    const applied = applyTemplateData(template, {
+      assetHeadline: '<h2>Title</h2>',
+      pdfAsset: pdfUrl,
+    });
+    const out = injectAssetHeadlineIfMissing(template, applied, '<h2>Duplicate</h2>', pdfUrl);
+    expect(out).to.include('<h2>Title</h2>');
+    expect(out).to.not.include('<h2>Duplicate</h2>');
   });
 });

--- a/test/tools/generator/landing-page.test.html
+++ b/test/tools/generator/landing-page.test.html
@@ -329,6 +329,35 @@
           expect(missingFields).to.include('marketoPOI');
         });
 
+        it('shows asset headline field for gated non-video content types', async () => {
+          setValue('contentType', 'Report');
+          setValue('gated', 'Gated');
+          setValue('region', '/');
+          setValue('marqueeHeadline', 'Test Report');
+
+          setPageName('test-report');
+          await tick(100);
+
+          shadowRoot.querySelector('sl-button.confirm').click();
+          await tick(100);
+
+          const assetHeadline = shadowRoot.querySelector('[name="assetHeadline"]');
+          expect(assetHeadline).to.exist;
+          expect(assetHeadline.getAttribute('label')).to.equal('Asset Headline');
+        });
+
+        it('hides asset headline field for ungated content types', async () => {
+          fillCoreFields();
+          setPageName();
+          await tick(100);
+
+          shadowRoot.querySelector('sl-button.confirm').click();
+          await tick(100);
+
+          const assetHeadline = shadowRoot.querySelector('[name="assetHeadline"]');
+          expect(assetHeadline).to.not.exist;
+        });
+
         it('isEmpty correctly identifies empty values', () => {
           const testCases = [
             { input: '', expected: true, description: 'empty string' },

--- a/tools/generator/form-sections.js
+++ b/tools/generator/form-sections.js
@@ -238,10 +238,14 @@ export function renderExperienceFragment(form, handleInput, { fragmentOptions },
 export function renderAssetDelivery(form, handleInput, handlePdfChange, hasError = () => '') {
   const pdfError = hasError('pdfAsset');
   const pdfViewUrl = getDisplayUrl(form.pdfAsset?.path);
+  const isVideo = (form.contentType || '').toLowerCase().includes('video');
+  const showAssetHeadline = form.gated === 'Gated' && !isVideo;
   return html`
     <div class="form-row">
       <h2>Asset Delivery</h2>
-      ${(form.contentType || '').toLowerCase().includes('video') ? html`
+      ${showAssetHeadline ? html`
+        <sl-input type="text" name="assetHeadline" .value=${form.assetHeadline} placeholder="Asset Headline" label="Asset Headline" @input=${handleInput}></sl-input>` : nothing}
+      ${isVideo ? html`
         <sl-input type="text" name="videoAsset" .value=${form.videoAsset} placeholder="https://video.tv.adobe.com/v/..." label="Video Asset*" error=${hasError('videoAsset')} @input=${handleInput}></sl-input>`
     : html`
         <div class="pdf-upload-container">

--- a/tools/generator/generator.js
+++ b/tools/generator/generator.js
@@ -55,6 +55,33 @@ export function applyTemplateData(templateStr, data) {
   return html.replaceAll('template-', '');
 }
 
+const ASSET_HEADLINE_PLACEHOLDER = /\{\{\s*asset-headline\s*\}\}/i;
+
+/**
+ * When the authoring template omits {{asset-headline}}, inject the authored h2
+ * immediately before the PDF link so gated Guide / Infographic / Report pages
+ * still show the asset headline (LPB always supplies placeholders.assetHeadline).
+ */
+export function injectAssetHeadlineIfMissing(
+  templateHtml,
+  generatedHtml,
+  assetHeadlineHtml,
+  pdfAssetUrl,
+) {
+  if (!assetHeadlineHtml || !pdfAssetUrl) return generatedHtml;
+  if (ASSET_HEADLINE_PLACEHOLDER.test(templateHtml)) return generatedHtml;
+  if (generatedHtml.includes(assetHeadlineHtml)) return generatedHtml;
+
+  const escaped = pdfAssetUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const paraAnchor = new RegExp(`(<p[^>]*>\\s*)(<a href="${escaped}"[^>]*>)`, 'i');
+  if (paraAnchor.test(generatedHtml)) {
+    return generatedHtml.replace(paraAnchor, `${assetHeadlineHtml}$1$2`);
+  }
+  const bareAnchor = new RegExp(`(<a href="${escaped}"[^>]*>)`, 'i');
+  if (!bareAnchor.test(generatedHtml)) return generatedHtml;
+  return generatedHtml.replace(bareAnchor, `${assetHeadlineHtml}$1`);
+}
+
 export function getStorageItem(key, defaultValue = null) {
   try {
     const item = localStorage.getItem(key);

--- a/tools/generator/landing-page.js
+++ b/tools/generator/landing-page.js
@@ -114,6 +114,7 @@ const FORM_SCHEMA = {
   seoMetadataTitle: '',
   seoMetadataDescription: '',
   experienceFragment: '',
+  assetHeadline: '',
   videoAsset: '',
   pdfAsset: null,
   url: '',
@@ -433,6 +434,8 @@ class LandingPageForm extends LitElement {
     const videoVisible = this.form.contentType === 'Video/Demo';
     const pdfVisible = !videoVisible;
 
+    const assetHeadlineVisible = form.gated === 'Gated' && !videoVisible;
+
     const placeholders = {
       ...form,
       marketoDataUrl: marketoUrl(marketoState),
@@ -446,6 +449,7 @@ class LandingPageForm extends LitElement {
       marqueeImage: marqueeImgVisible ? getContentUrl(form.marqueeImage?.path) : '',
       bodyImage: getContentUrl(form.bodyImage?.path),
       cardImage: getContentUrl(form.cardImage?.path),
+      assetHeadline: assetHeadlineVisible && form.assetHeadline ? `<h2>${form.assetHeadline}</h2>` : '',
       pdfAsset: pdfVisible && form.pdfAsset ? getAemPageUrl(form.pdfAsset?.path) : '',
       pdfAssetName: pdfVisible && form.pdfAsset ? form.pdfAsset?.name : '',
       videoAsset: videoVisible ? form.videoAsset : '',

--- a/tools/generator/landing-page.js
+++ b/tools/generator/landing-page.js
@@ -26,6 +26,7 @@ import {
   setStorageItem,
   marketoUrl,
   applyTemplateData,
+  injectAssetHeadlineIfMissing,
   addHiddenTable,
 } from './generator.js';
 import {
@@ -711,6 +712,12 @@ class LandingPageForm extends LitElement {
       console.table(placeholders);
     }
     let generatedPage = applyTemplateData(this.templateHTML, placeholders);
+    generatedPage = injectAssetHeadlineIfMissing(
+      this.templateHTML,
+      generatedPage,
+      placeholders.assetHeadline,
+      placeholders.pdfAsset,
+    );
     generatedPage = addHiddenTable(generatedPage, { name: FORM_STORAGE_KEY, version: LPB_VERSION }, 'page-builder');
     if (DEBUG) generatedPage = addHiddenTable(generatedPage, this.form, 'form-data');
 


### PR DESCRIPTION
Add Asset Headline field to LPB for gated content types (Guides, Infographics, Reports).

Resolves: [MWPW-191070](https://jira.corp.adobe.com/browse/MWPW-191070)

## Summary
Adds an optional `Asset Headline` input to the LPB's **Asset Delivery** section. When authored, the value is wrapped in an `<h2>` and injected into the template's `{{asset-headline}}` placeholder, rendering above the PDF on the generated page (matching pages like [media-and-entertainment-digital-trends](https://business.adobe.com/resources/reports/media-and-entertainment-digital-trends.html?form=off)).

## Visibility rule
The field is shown only when **Gated** is selected **and** Content Type is **not** Video/Demo i.e. gated Guide, Infographic, and Report. It is hidden for all ungated content types and for gated Video/Demo.

## LPB form
https://da.live/app/adobecom/da-bacom/tools/generator/landing-page?ref=add-headline-to-lpb-reports-template

<img width="1259" height="299" alt="Asset Headline field in Asset Delivery section" src="https://github.com/user-attachments/assets/52e576dc-db8c-423e-8456-da38c83c7d24" />

## Template dependency (out of scope)
The `<h2>` only renders on the published page once the corresponding DA template contains `{{asset-headline}}` above its PDF/asset block:

- `report-gated` → `/tools/page-builder/landing-pages/one-page-gated-lp-placeholders`
- `guide-gated` / `infographic-gated` → `/tools/page-builder/prd-template-basic`

Authoring those templates is not part of this ticket. The LPB code is a no-op when the placeholder is absent (value saves; nothing renders). Follow-up authoring work can be tracked separately.

## Tests

### Unit (Web Test Runner)
- `applyTemplateData` wraps the value in `<h2>` and strips the placeholder when empty
- Field visibility: shown for gated Report, hidden for ungated

### E2E (Nala / Playwright)
Added under a new "2.2 Asset Headline" block in the LPB form/field suite:

- `@lpb-asset-headline-gated-report-visible`: Gated Report shows the `Asset Headline` input inside the Asset Delivery section with the correct label
- `@lpb-asset-headline-ungated-guide-hidden`: Ungated Guide hides the input
- `@lpb-asset-headline-gated-video-hidden`: Gated Video/Demo hides the input (video branch still shows `videoAsset`)
- `@lpb-asset-headline-toggle-gated-to-ungated`: Toggling Gated → Ungated live (no reload) hides the input

Run them with:

LPB_REF=add-headline-to-lpb-reports-template npm run nala local @asset-headline

**Note**: @lpb-reset-clears-storage intermittently fails in the non-E2E suite. It's a pre-existing flaky test unrelated to this change. It breaks on logic not touched here.

**How to Verify**
1. Open the LPB form above.
2. Core Options → Content Type Report (or Guide / Infographic), Gated Gated, any Region, any Marquee Headline, any Page Name → Confirm.
3. Asset Delivery → confirm new Asset Headline input is present above the PDF upload.
4. Toggle Gated → Ungated, or Content Type → Video/Demo → field is hidden.
5. (QA, once templates updated) Upload a PDF, generate the page, confirm the authored headline renders as an h2 above the PDF on preview/live.