### PR TITLE
feat: add quickedit

### DIFF
--- a/scripts/quick-edit.js
+++ b/scripts/quick-edit.js
@@ -14,7 +14,7 @@ function addImportmap() {
   document.head.appendChild(importmapEl);
 }
 
-async function loadMoudle(origin, payload) {
+async function loadModule(origin, payload) {
   const { default: loadQuickEdit } = await import(`${origin}/nx/public/plugins/quick-edit/quick-edit.js`);
   loadQuickEdit(payload, loadPage);
 }

--- a/scripts/quick-edit.js
+++ b/scripts/quick-edit.js
@@ -1,0 +1,48 @@
+import { loadPage } from './scripts.js';
+
+const importMap = {
+  imports: {
+    'da-lit': 'https://da.live/deps/lit/dist/index.js',
+    'da-y-wrapper': 'https://da.live/deps/da-y-wrapper/dist/index.js',
+  },
+};
+
+function addImportmap() {
+  const importmapEl = document.createElement('script');
+  importmapEl.type = 'importmap';
+  importmapEl.textContent = JSON.stringify(importMap);
+  document.head.appendChild(importmapEl);
+}
+
+async function loadMoudle(origin, payload) {
+  const { default: loadQuickEdit } = await import(`${origin}/nx/public/plugins/quick-edit/quick-edit.js`);
+  loadQuickEdit(payload, loadPage);
+}
+
+// creates sidekick payload when loading QE from query param
+function generateSidekickPayload() {
+  let { hostname } = window.location;
+  if (hostname === 'localhost') {
+    hostname = document.querySelector('meta[property="hlx:proxyUrl"]').content;
+  }
+  const parts = hostname.split('.')[0].split('--');
+  const [, repo, owner] = parts;
+
+  return {
+    detail: {
+      config: { mountpoint: `https://content.da.live/${owner}/${repo}/` },
+      location: { pathname: window.location.pathname },
+    },
+  };
+}
+
+export default function init(payload) {
+  const { search } = window.location;
+  const ref = new URLSearchParams(search).get('quick-edit');
+  let origin;
+  if (ref === 'on' || !ref) origin = 'https://da.live';
+  if (ref === 'local') origin = 'http://localhost:6456';
+  if (!origin) origin = `https://${ref}--da-nx--adobe.aem.live`;
+  addImportmap();
+  loadMoudle(origin, payload || generateSidekickPayload());
+}

--- a/scripts/quick-edit.js
+++ b/scripts/quick-edit.js
@@ -44,5 +44,5 @@ export default function init(payload) {
   if (ref === 'local') origin = 'http://localhost:6456';
   if (!origin) origin = `https://${ref}--da-nx--adobe.aem.live`;
   addImportmap();
-  loadMoudle(origin, payload || generateSidekickPayload());
+  loadModule(origin, payload || generateSidekickPayload());
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -240,7 +240,7 @@ export const EVENT_LIBS = (() => {
 
 let eventsError;
 
-async function loadPage() {
+export async function loadPage() {
   const {
     loadArea, loadLana, setConfig, createTag, getMetadata, getLocale,
   } = await import(`${LIBS}/utils/utils.js`);
@@ -336,6 +336,9 @@ loadPage();
   if (!new URL(window.location.href).searchParams.get('dapreview')) return;
   // eslint-disable-next-line import/no-unresolved
   import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
+  const hasQE = searchParams.has('quick-edit');
+  // eslint-disable-next-line import/no-unresolved
+  if (hasQE) import('./quick-edit.js').then((mod) => mod.default());
 }());
 
 if (eventsError) {


### PR DESCRIPTION
## Summary

- Adds `scripts/quick-edit.js` to support DA Quick Edit functionality, which loads the Quick Edit plugin from `da.live`
- Wires up Quick Edit in `scripts.js` so it is initialized when the `?quick-edit` query parameter is present during DA live preview

## Test plan

- [ ] Load a page with `?dapreview&quick-edit=on` and verify the Quick Edit plugin loads correctly
- [ ] Test with `?dapreview&quick-edit=local` to verify it points to `localhost:6456`
- [ ] Test with a branch ref (e.g. `?dapreview&quick-edit=my-branch--da-nx--adobe`) to verify custom origin resolution

Test: https://stage--da-bacom--adobecom.aem.live/?martech?quickedit=on