### PR TITLE
fix CodeQL incomplete URL substring sanitization in JWT key check

### DIFF
--- a/tools/generator/lpb-log.js
+++ b/tools/generator/lpb-log.js
@@ -87,6 +87,25 @@ export function decodeJwtPayloadSegment(segment) {
   }
 }
 
+const ADOBE_ALLOWED_DOMAINS = ['adobe.com', 'adobelogin.com'];
+
+function isAllowedHost(hostname) {
+  const host = String(hostname || '').toLowerCase();
+  return ADOBE_ALLOWED_DOMAINS.some((domain) => host === domain || host.endsWith(`.${domain}`));
+}
+
+function isAdobeNamespacedKey(key) {
+  if (!key || typeof key !== 'string') return false;
+  try {
+    const { hostname } = new URL(key);
+    return !!(hostname && isAllowedHost(hostname));
+  } catch {
+    // Not a URL; fall through to strict token matching.
+  }
+  const lower = key.toLowerCase();
+  return /(^|[./:@_-])(adobe\.com|adobelogin\.com)([./:@_-]|$)/.test(lower);
+}
+
 function imsPublisherFromPayload(payload) {
   if (!payload || typeof payload !== 'object') return null;
   if (payload.email) return String(payload.email);
@@ -95,7 +114,7 @@ function imsPublisherFromPayload(payload) {
   if (payload.user_id) return String(payload.user_id);
   if (payload.sub) return String(payload.sub);
   for (const key of Object.keys(payload)) {
-    if (key.includes('adobelogin.com') || key.includes('adobe.com')) {
+    if (isAdobeNamespacedKey(key)) {
       const v = payload[key];
       if (typeof v === 'string' && v.includes('@')) return v;
       if (v && typeof v === 'object') {


### PR DESCRIPTION
- Resolves CodeQL finding js/incomplete-url-substring-sanitization flagged on imsPublisherFromPayload on this [PR](https://github.com/adobecom/da-bacom/pull/160)
  - Replaces raw .includes('adobe.com') substring check on JWT claim keys with proper URL parsing via new URL() and exact hostname matching
  - Adds regex fallback for non-URL-shaped keys (bare JWT claim names) so no valid Adobe-namespaced claims are dropped

  **Test Plan**
  - Existing unit tests pass (npm run test) ✅ 
  - Verify CodeQL check clears on the PR