### PR TITLE
MWPW-188278: inline hreflang sitemap caching into head.html

### DIFF
--- a/head.html
+++ b/head.html
@@ -38,14 +38,113 @@
   const LOCALES = ['ae_ar', 'ae_en', 'africa', 'ar', 'at', 'au', 'be_en', 'be_fr', 'be_nl', 'bg', 'br', 'ca_fr', 'ca', 'ch_de', 'ch_fr', 'ch_it', 'cl', 'cn', 'co', 'cr', 'cy_en', 'cz', 'de', 'dk', 'ec', 'ee', 'eg_ar', 'eg_en', 'el', 'es', 'fi', 'fr', 'gr_el', 'gr_en', 'gt', 'hk_en', 'hk_zh', 'hu', 'id_en', 'id_id', 'ie', 'il_en', 'il_he', 'in_hi', 'in', 'it', 'jp', 'kr', 'kw_ar', 'kw_en', 'la', 'langstore', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'lv', 'mena_ar', 'mena_en', 'mt', 'mx', 'my_en', 'my_ms', 'ng', 'nl', 'no', 'nz', 'pe', 'ph_en', 'ph_fil', 'pl', 'pr', 'pt', 'qa_ar', 'qa_en', 'ro', 'ru', 'sa_ar', 'sa_en', 'se', 'sg', 'si', 'sk', 'th_en', 'th_th', 'tr', 'tw', 'ua', 'uk', 'vn_en', 'vn_vi', 'za'];
 
   if (!headAlreadyLoaded) {
-    import(`${libs}/features/hreflang/hreflang.js`).then(({ appendHreflangLinks }) => {
-      console.log('[hreflang] module loaded, calling appendHreflangLinks');
-      appendHreflangLinks({
-        locales: LOCALES,
-        sitemapTemplate: '/{locale}/sitemap.xml',
-        sitemapOrigin: 'https://business.adobe.com',
+    // --- hreflang config (change these two lines per property) ---
+    const HREFLANG_ORIGIN = 'https://business.adobe.com';
+    const HREFLANG_TEMPLATE = '/{locale}/sitemap.xml';
+    // ------------------------------------------------------------
+    const HREFLANG_CACHE_PREFIX = 'hreflang-';
+    const HREFLANG_TIMEOUT_MS = 5000;
+
+    function buildHreflangMap(xmlDoc) {
+      const map = {};
+      xmlDoc.querySelectorAll('url').forEach((urlEl) => {
+        const loc = urlEl.querySelector('loc')?.textContent;
+        if (!loc) return;
+        const links = [...urlEl.querySelectorAll('link[rel="alternate"]')]
+          .map((el) => ({ hreflang: el.getAttribute('hreflang'), href: el.getAttribute('href') }))
+          .filter((l) => l.hreflang && l.href);
+        if (links.length) map[loc] = links;
       });
-    });
+      return map;
+    }
+
+    function getCachedMap(cacheKey) {
+      try { return JSON.parse(sessionStorage.getItem(cacheKey)); } catch { return null; }
+    }
+
+    function setCachedMap(cacheKey, map) {
+      try { sessionStorage.setItem(cacheKey, JSON.stringify(map)); } catch {
+        window.lana?.log('hreflang: sessionStorage quota exceeded', { tags: 'hreflang', severity: 'warning' });
+      }
+    }
+
+    async function fetchSitemapMap(sitemapUrl) {
+      const ctrl = new AbortController();
+      const tid = setTimeout(() => ctrl.abort(), HREFLANG_TIMEOUT_MS);
+      try {
+        const res = await fetch(sitemapUrl, { signal: ctrl.signal });
+        if (!res.ok) {
+          window.lana?.log(`hreflang: fetch failed (${res.status}) ${sitemapUrl}`, { tags: 'hreflang', severity: 'error' });
+          return null;
+        }
+        const xmlDoc = new DOMParser().parseFromString(await res.text(), 'text/xml');
+        if (xmlDoc.querySelector('parsererror')) {
+          window.lana?.log(`hreflang: parse failed ${sitemapUrl}`, { tags: 'hreflang', severity: 'error' });
+          return null;
+        }
+        return buildHreflangMap(xmlDoc);
+      } catch (e) {
+        const msg = e.name === 'AbortError'
+          ? `hreflang: timeout fetching ${sitemapUrl}`
+          : `hreflang: error fetching ${sitemapUrl} - ${e.message}`;
+        window.lana?.log(msg, { tags: 'hreflang', severity: 'error' });
+        return null;
+      } finally {
+        clearTimeout(tid);
+      }
+    }
+
+    function getSitemapPath(localeMatch) {
+      if (!HREFLANG_TEMPLATE.includes('{locale}')) {
+        window.lana?.log(`hreflang: HREFLANG_TEMPLATE missing {locale} placeholder: ${HREFLANG_TEMPLATE}`, { tags: 'hreflang', severity: 'error' });
+        return HREFLANG_TEMPLATE;
+      }
+      return localeMatch
+        ? HREFLANG_TEMPLATE.replace('{locale}', localeMatch)
+        : HREFLANG_TEMPLATE.replace(/\/?{locale}/, '');
+    }
+
+    function getPageUrl(pathname, localeMatch) {
+      const isLocaleRoot = localeMatch && pathname === `/${localeMatch}/`;
+      if (pathname === '/' || isLocaleRoot) return `${HREFLANG_ORIGIN}${pathname}`;
+      const normalized = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+      return `${HREFLANG_ORIGIN}${normalized.endsWith('.html') ? normalized : `${normalized}.html`}`;
+    }
+
+    function injectHreflangLinks(links) {
+      const titleEl = document.head.querySelector('title');
+      if (!titleEl) return;
+      titleEl.after(...links.map(({ hreflang, href }) => {
+        const el = document.createElement('link');
+        el.setAttribute('rel', 'alternate');
+        el.setAttribute('hreflang', hreflang);
+        el.setAttribute('href', href);
+        return el;
+      }));
+    }
+
+    (async () => {
+      const uaMeta = document.querySelector('meta[name="hreflinksuseragents"]');
+      if (!uaMeta?.content) return;
+      if (!uaMeta.content.split(',').some((a) => navigator.userAgent.includes(a.trim()))) return;
+
+      const { pathname } = window.location;
+      const localeMatch = LOCALES.find((l) => pathname.startsWith(`/${l}/`));
+      const sitemapPath = getSitemapPath(localeMatch);
+      const sitemapUrl = `${window.location.origin}${sitemapPath}`;
+      const cacheKey = HREFLANG_CACHE_PREFIX + sitemapPath;
+
+      let map = getCachedMap(cacheKey);
+      if (!map) {
+        map = await fetchSitemapMap(sitemapUrl);
+        if (!map) return;
+        setCachedMap(cacheKey, map);
+      }
+
+      const pageUrl = getPageUrl(pathname, localeMatch);
+      const links = map[pageUrl] ?? map[pageUrl.replace(/\/$/, '')];
+      if (links?.length) injectHreflangLinks(links);
+    })();
   }
 
   const sheetSchema = document.querySelector('[type="application/ld+json"]');

--- a/head.html
+++ b/head.html
@@ -35,93 +35,18 @@
     document.head.append(miloStyles, miloUtils, miloDecorate); 
   }
 
-  function buildLink(language, url) {
-    const link = document.createElement('link');
-    link.setAttribute('rel', 'alternate');
-    link.setAttribute('hreflang', language);
-    link.setAttribute('href', url);
-    return link;
-  }
-
-  const userAgentMeta = document.querySelector('meta[name="hreflinksuseragents"]');
-  const allowedAgents = userAgentMeta && userAgentMeta.content.split(',');
-  const userAgentString = window.navigator.userAgent;
-  const isAllowedAgent = allowedAgents && allowedAgents.some((agent) => userAgentString.includes(agent.trim()));
-
   const LOCALES = ['ae_ar', 'ae_en', 'africa', 'ar', 'at', 'au', 'be_en', 'be_fr', 'be_nl', 'bg', 'br', 'ca_fr', 'ca', 'ch_de', 'ch_fr', 'ch_it', 'cl', 'cn', 'co', 'cr', 'cy_en', 'cz', 'de', 'dk', 'ec', 'ee', 'eg_ar', 'eg_en', 'el', 'es', 'fi', 'fr', 'gr_el', 'gr_en', 'gt', 'hk_en', 'hk_zh', 'hu', 'id_en', 'id_id', 'ie', 'il_en', 'il_he', 'in_hi', 'in', 'it', 'jp', 'kr', 'kw_ar', 'kw_en', 'la', 'langstore', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'lv', 'mena_ar', 'mena_en', 'mt', 'mx', 'my_en', 'my_ms', 'ng', 'nl', 'no', 'nz', 'pe', 'ph_en', 'ph_fil', 'pl', 'pr', 'pt', 'qa_ar', 'qa_en', 'ro', 'ru', 'sa_ar', 'sa_en', 'se', 'sg', 'si', 'sk', 'th_en', 'th_th', 'tr', 'tw', 'ua', 'uk', 'vn_en', 'vn_vi', 'za'];
 
-  (() => {
-    async function fetchAndParseSitemap() {
-      const sitemapOrigin = 'https://business.adobe.com';
-      const { origin, pathname } = window.location;
-
-      let sitemapPath = '/sitemap.xml';
-      const localeMatch = LOCALES.find(locale => pathname.startsWith(`/${locale}/`));
-
-      if (localeMatch) {
-        sitemapPath = `/${localeMatch}/sitemap.xml`;
-      }
-      
-      try {
-        const response = await fetch(`${origin}${sitemapPath}`);
-        if (!response.ok) {
-          console.warn('Failed to fetch sitemap:', response.status);
-          return;
-        }
-        
-        const xmlText = await response.text();
-        const parser = new DOMParser();
-        const xmlDoc = parser.parseFromString(xmlText, 'text/xml');
-        const parseError = xmlDoc.querySelector('parsererror');
-        if (parseError) {
-          return;
-        }
-        
-        const urlElements = xmlDoc.querySelectorAll('url');
-        let currentUrlElement = null;
-        const correctedPath = pathname.includes('html') ? pathname : `${pathname}.html`
-        const isLocalRoot = `${sitemapOrigin}/${localeMatch}/` === `${sitemapOrigin}${pathname}`;
-        const rootPage = isLocalRoot ? `${sitemapOrigin}/${localeMatch}/` : `${sitemapOrigin}/`; 
-        const currentPageUrl = pathname !== '/' && pathname !== `/${localeMatch}/` ? `${sitemapOrigin}${correctedPath}` : `${rootPage}`;
-
-        for (const urlElement of urlElements) {
-          const loc = urlElement.querySelector('loc')?.textContent;
-          if (loc === currentPageUrl || loc === currentPageUrl.replace(/\/$/, '')) {
-            currentUrlElement = urlElement;
-            break;
-          }
-        }
-        
-        if (!currentUrlElement) {
-          console.warn('Current page not found in sitemap');
-          return;
-        }
-        
-        const alternateLinks = currentUrlElement.querySelectorAll('link[rel="alternate"]');
-        const linkElements = [];
-
-        alternateLinks.forEach(altLink => {
-          const hreflang = altLink.getAttribute('hreflang');
-          const href = altLink.getAttribute('href');
-          
-          if (hreflang && href) {
-            linkElements.push(buildLink(hreflang, href));
-          }
-        });
-        
-        const titleElement = document.head.querySelector('title');
-        if (linkElements.length > 0 && titleElement) {
-          titleElement.after(...linkElements);
-        }
-      } catch (error) {
-        console.error('Error fetching or parsing sitemap:', error);
-      }
-    } 
-
-    if (isAllowedAgent && !headAlreadyLoaded) {
-      fetchAndParseSitemap();
-    }
-  })();
+  if (!headAlreadyLoaded) {
+    import(`${libs}/features/hreflang/hreflang.js`).then(({ appendHreflangLinks }) => {
+      console.log('[hreflang] module loaded, calling appendHreflangLinks');
+      appendHreflangLinks({
+        locales: LOCALES,
+        sitemapTemplate: '/{locale}/sitemap.xml',
+        sitemapOrigin: 'https://business.adobe.com',
+      });
+    });
+  }
 
   const sheetSchema = document.querySelector('[type="application/ld+json"]');
 

--- a/head.html
+++ b/head.html
@@ -64,7 +64,12 @@
       }
 
       function setCachedMap(cacheKey, map) {
-        try { sessionStorage.setItem(cacheKey, JSON.stringify(map)); } catch {
+        try {
+          Object.keys(sessionStorage)
+            .filter((k) => k.startsWith(HREFLANG_CACHE_PREFIX) && k !== cacheKey)
+            .forEach((k) => sessionStorage.removeItem(k));
+          sessionStorage.setItem(cacheKey, JSON.stringify(map));
+        } catch {
           window.lana?.log('hreflang: sessionStorage quota exceeded', { tags: 'hreflang', severity: 'warning' });
         }
       }

--- a/head.html
+++ b/head.html
@@ -38,92 +38,92 @@
   const LOCALES = ['ae_ar', 'ae_en', 'africa', 'ar', 'at', 'au', 'be_en', 'be_fr', 'be_nl', 'bg', 'br', 'ca_fr', 'ca', 'ch_de', 'ch_fr', 'ch_it', 'cl', 'cn', 'co', 'cr', 'cy_en', 'cz', 'de', 'dk', 'ec', 'ee', 'eg_ar', 'eg_en', 'el', 'es', 'fi', 'fr', 'gr_el', 'gr_en', 'gt', 'hk_en', 'hk_zh', 'hu', 'id_en', 'id_id', 'ie', 'il_en', 'il_he', 'in_hi', 'in', 'it', 'jp', 'kr', 'kw_ar', 'kw_en', 'la', 'langstore', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'lv', 'mena_ar', 'mena_en', 'mt', 'mx', 'my_en', 'my_ms', 'ng', 'nl', 'no', 'nz', 'pe', 'ph_en', 'ph_fil', 'pl', 'pr', 'pt', 'qa_ar', 'qa_en', 'ro', 'ru', 'sa_ar', 'sa_en', 'se', 'sg', 'si', 'sk', 'th_en', 'th_th', 'tr', 'tw', 'ua', 'uk', 'vn_en', 'vn_vi', 'za'];
 
   if (!headAlreadyLoaded) {
-    // --- hreflang config (change these two lines per property) ---
-    const HREFLANG_ORIGIN = 'https://business.adobe.com';
-    const HREFLANG_TEMPLATE = '/{locale}/sitemap.xml';
-    // ------------------------------------------------------------
-    const HREFLANG_CACHE_PREFIX = 'hreflang-';
-    const HREFLANG_TIMEOUT_MS = 5000;
-
-    function buildHreflangMap(xmlDoc) {
-      const map = {};
-      xmlDoc.querySelectorAll('url').forEach((urlEl) => {
-        const loc = urlEl.querySelector('loc')?.textContent;
-        if (!loc) return;
-        const links = [...urlEl.querySelectorAll('link[rel="alternate"]')]
-          .map((el) => ({ hreflang: el.getAttribute('hreflang'), href: el.getAttribute('href') }))
-          .filter((l) => l.hreflang && l.href);
-        if (links.length) map[loc] = links;
-      });
-      return map;
-    }
-
-    function getCachedMap(cacheKey) {
-      try { return JSON.parse(sessionStorage.getItem(cacheKey)); } catch { return null; }
-    }
-
-    function setCachedMap(cacheKey, map) {
-      try { sessionStorage.setItem(cacheKey, JSON.stringify(map)); } catch {
-        window.lana?.log('hreflang: sessionStorage quota exceeded', { tags: 'hreflang', severity: 'warning' });
-      }
-    }
-
-    async function fetchSitemapMap(sitemapUrl) {
-      const ctrl = new AbortController();
-      const tid = setTimeout(() => ctrl.abort(), HREFLANG_TIMEOUT_MS);
-      try {
-        const res = await fetch(sitemapUrl, { signal: ctrl.signal });
-        if (!res.ok) {
-          window.lana?.log(`hreflang: fetch failed (${res.status}) ${sitemapUrl}`, { tags: 'hreflang', severity: 'error' });
-          return null;
-        }
-        const xmlDoc = new DOMParser().parseFromString(await res.text(), 'text/xml');
-        if (xmlDoc.querySelector('parsererror')) {
-          window.lana?.log(`hreflang: parse failed ${sitemapUrl}`, { tags: 'hreflang', severity: 'error' });
-          return null;
-        }
-        return buildHreflangMap(xmlDoc);
-      } catch (e) {
-        const msg = e.name === 'AbortError'
-          ? `hreflang: timeout fetching ${sitemapUrl}`
-          : `hreflang: error fetching ${sitemapUrl} - ${e.message}`;
-        window.lana?.log(msg, { tags: 'hreflang', severity: 'error' });
-        return null;
-      } finally {
-        clearTimeout(tid);
-      }
-    }
-
-    function getSitemapPath(localeMatch) {
-      if (!HREFLANG_TEMPLATE.includes('{locale}')) {
-        window.lana?.log(`hreflang: HREFLANG_TEMPLATE missing {locale} placeholder: ${HREFLANG_TEMPLATE}`, { tags: 'hreflang', severity: 'error' });
-        return HREFLANG_TEMPLATE;
-      }
-      return localeMatch
-        ? HREFLANG_TEMPLATE.replace('{locale}', localeMatch)
-        : HREFLANG_TEMPLATE.replace(/\/?{locale}/, '');
-    }
-
-    function getPageUrl(pathname, localeMatch) {
-      const isLocaleRoot = localeMatch && pathname === `/${localeMatch}/`;
-      if (pathname === '/' || isLocaleRoot) return `${HREFLANG_ORIGIN}${pathname}`;
-      const normalized = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
-      return `${HREFLANG_ORIGIN}${normalized.endsWith('.html') ? normalized : `${normalized}.html`}`;
-    }
-
-    function injectHreflangLinks(links) {
-      const titleEl = document.head.querySelector('title');
-      if (!titleEl) return;
-      titleEl.after(...links.map(({ hreflang, href }) => {
-        const el = document.createElement('link');
-        el.setAttribute('rel', 'alternate');
-        el.setAttribute('hreflang', hreflang);
-        el.setAttribute('href', href);
-        return el;
-      }));
-    }
-
     (async () => {
+      // --- hreflang config (change these two lines per property) ---
+      const HREFLANG_ORIGIN = 'https://business.adobe.com';
+      const HREFLANG_TEMPLATE = '/{locale}/sitemap.xml';
+      // ------------------------------------------------------------
+      const HREFLANG_CACHE_PREFIX = 'hreflang-';
+      const HREFLANG_TIMEOUT_MS = 5000;
+
+      function buildHreflangMap(xmlDoc) {
+        const map = {};
+        xmlDoc.querySelectorAll('url').forEach((urlEl) => {
+          const loc = urlEl.querySelector('loc')?.textContent;
+          if (!loc) return;
+          const links = [...urlEl.querySelectorAll('link[rel="alternate"]')]
+            .map((el) => ({ hreflang: el.getAttribute('hreflang'), href: el.getAttribute('href') }))
+            .filter((l) => l.hreflang && l.href);
+          if (links.length) map[loc] = links;
+        });
+        return map;
+      }
+
+      function getCachedMap(cacheKey) {
+        try { return JSON.parse(sessionStorage.getItem(cacheKey)); } catch { return null; }
+      }
+
+      function setCachedMap(cacheKey, map) {
+        try { sessionStorage.setItem(cacheKey, JSON.stringify(map)); } catch {
+          window.lana?.log('hreflang: sessionStorage quota exceeded', { tags: 'hreflang', severity: 'warning' });
+        }
+      }
+
+      async function fetchSitemapMap(sitemapUrl) {
+        const ctrl = new AbortController();
+        const tid = setTimeout(() => ctrl.abort(), HREFLANG_TIMEOUT_MS);
+        try {
+          const res = await fetch(sitemapUrl, { signal: ctrl.signal });
+          if (!res.ok) {
+            window.lana?.log(`hreflang: fetch failed (${res.status}) ${sitemapUrl}`, { tags: 'hreflang', severity: 'error' });
+            return null;
+          }
+          const xmlDoc = new DOMParser().parseFromString(await res.text(), 'text/xml');
+          if (xmlDoc.querySelector('parsererror')) {
+            window.lana?.log(`hreflang: parse failed ${sitemapUrl}`, { tags: 'hreflang', severity: 'error' });
+            return null;
+          }
+          return buildHreflangMap(xmlDoc);
+        } catch (e) {
+          const msg = e.name === 'AbortError'
+            ? `hreflang: timeout fetching ${sitemapUrl}`
+            : `hreflang: error fetching ${sitemapUrl} - ${e.message}`;
+          window.lana?.log(msg, { tags: 'hreflang', severity: 'error' });
+          return null;
+        } finally {
+          clearTimeout(tid);
+        }
+      }
+
+      function getSitemapPath(localeMatch) {
+        if (!HREFLANG_TEMPLATE.includes('{locale}')) {
+          window.lana?.log(`hreflang: HREFLANG_TEMPLATE missing {locale} placeholder: ${HREFLANG_TEMPLATE}`, { tags: 'hreflang', severity: 'error' });
+          return HREFLANG_TEMPLATE;
+        }
+        return localeMatch
+          ? HREFLANG_TEMPLATE.replace('{locale}', localeMatch)
+          : HREFLANG_TEMPLATE.replace(/\/?{locale}/, '');
+      }
+
+      function getPageUrl(pathname, localeMatch) {
+        const isLocaleRoot = localeMatch && pathname === `/${localeMatch}/`;
+        if (pathname === '/' || isLocaleRoot) return `${HREFLANG_ORIGIN}${pathname}`;
+        const normalized = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+        return `${HREFLANG_ORIGIN}${normalized.endsWith('.html') ? normalized : `${normalized}.html`}`;
+      }
+
+      function injectHreflangLinks(links) {
+        const titleEl = document.head.querySelector('title');
+        if (!titleEl) return;
+        titleEl.after(...links.map(({ hreflang, href }) => {
+          const el = document.createElement('link');
+          el.setAttribute('rel', 'alternate');
+          el.setAttribute('hreflang', hreflang);
+          el.setAttribute('href', href);
+          return el;
+        }));
+      }
+
       const uaMeta = document.querySelector('meta[name="hreflinksuseragents"]');
       if (!uaMeta?.content) return;
       if (!uaMeta.content.split(',').some((a) => navigator.userAgent.includes(a.trim()))) return;


### PR DESCRIPTION
## Problem

Bots crawling locale pages fetch the full sitemap XML on every page load to extract hreflang alternate links. Without caching, a bot crawling 1k pages downloads the sitemap 1k times per session.

**Resolves**: [MWPW-191067](https://jira.corp.adobe.com/browse/MWPW-191067)

**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.live/?martech=off
- After: https://sitemap-cache--da-bacom--adobecom.aem.live/?martech=off

Flagged in [da-cc PR #18](https://github.com/adobecom/da-cc/pull/18) (MWPW-188278).

## Solution

Inline sessionStorage caching for hreflang sitemap data directly in `head.html`:

- First page: fetch locale sitemap once, parse XML, store lightweight URL-to-hreflang map in sessionStorage
- Every subsequent page in the same session: skip fetch entirely, direct map lookup
- Bot-only via `meta[name="hreflinksuseragents"]` - no impact on regular users

## Config (two lines to adapt per property)

```js
const HREFLANG_ORIGIN = 'https://business.adobe.com';
const HREFLANG_TEMPLATE = '/{locale}/sitemap.xml';
```

## Test plan

- [ ] Spoof Googlebot UA in Chrome DevTools (Network Conditions) and verify hreflang links injected after `<title>` on a locale page
- [ ] Verify sessionStorage key `hreflang-/de/sitemap.xml` populated after first page load
- [ ] Verify second page load skips fetch (no sitemap network request)
- [ ] Remove UA spoof and verify no sitemap fetch for regular users