### PR TITLE
MWPW-195178 MWPW-195179: Upgrade Node.js to 24 in CI workflows

### DIFF
--- a/.github/workflows/nala-pr.yml
+++ b/.github/workflows/nala-pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
  - Upgraded Node.js 18 → 24 in run-lint.yml (MWPW-195178: Node 18 EOL April 2025)
  - Upgraded Node.js 20 → 24 in nala-pr.yml (MWPW-195179: Node 20 EOL April 2026)
  - Node 24 is current LTS; Node 22 skipped per Kodiak guidance (EOL April 2027)

Resolves: [MWPW-195179](https://jira.corp.adobe.com/browse/MWPW-195179)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--bacom--adobecom.aem.live/?martech=off
- After: https://fix-kodiak-issues--bacom--adobecom.aem.live/?martech=off
