### PR TITLE
MWPW-195179: Update Nala workflow node version

### DIFF
--- a/.github/workflows/run-nala.yaml
+++ b/.github/workflows/run-nala.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       - name: Set execute permission for nalarun.sh
         run: chmod +x ./nala/utils/pr.run.sh


### PR DESCRIPTION
## Summary
- Updates `node-version` in `.github/workflows/run-nala.yaml` from `20.x` to `24.x`
- Node 20 reached end-of-life April 2026; Node 24 is the recommended upgrade path
- The previous fix (#176) updated `nala-pr.yml` and `run-lint.yml` but missed this workflow file

## Test plan
- [ ] Verify Nala E2E tests run successfully with Node 24 on a PR with the `run-nala` label
- [ ] Confirm Kodiak security finding resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)