### PR TITLE
koidak node update

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
## Summary
- Upgrades Node.js from 20.x to 24.x in `.github/workflows/run-tests.yaml`
- Node 20 reached EOL April 2026; this resolves the Kodiak security finding MWPW-195179
- Consistent with the Node 24 upgrade already applied to `nala-pr.yml` and `run-lint.yml` in #176

## Test plan
- [ ] CI unit tests pass with Node 24
- [ ] Verify Kodiak finding MWPW-195179 resolves after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)