### PR TITLE
Fix video modal not opening on direct navigation to #watch-video hash

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -365,6 +365,22 @@ export async function loadPage() {
 
   await loadArea();
 
+  // Milo loads modal blocks before decorateButtons strips #_button-XX from data-modal-hash,
+  // so init() sees a mismatched hash and skips deep-link opening. Re-check after loadArea
+  // when button decoration is complete and the hash is normalized.
+  const { hash } = window.location;
+  if (hash && !document.querySelector(`div.dialog-modal${hash}`)) {
+    const modalEl = document.querySelector(`a[data-modal-hash="${hash}"]`);
+    if (modalEl) {
+      const { findDetails, getModal } = await import(`${LIBS}/blocks/modal/modal.js`);
+      const details = await findDetails(hash, modalEl);
+      if (details?.path) {
+        details.deepLink = true;
+        getModal(details);
+      }
+    }
+  }
+
   if (getMetadata('iswa-typography') === 'on') applyIswaTypography();
 
   if (eventMD && eventUtils?.eventsDelayedActions) {


### PR DESCRIPTION
## Summary

- Video modal on `products/journey-optimizer.html` fails to open when navigating directly to `#watch-video` (e.g. from blog page CTAs), but works when clicking the in-page watch overview CTA
- Root cause: Milo loads modal blocks (calling `modal.js` `init()`) before `decorateButtons()` strips the `#_button-fill` style modifier from `data-modal-hash`. At `init()` time the hash is `#watch-video#_button-fill`, which doesn't match `window.location.hash` (`#watch-video`), so the deep-link is silently skipped
- Fix: after `loadArea()` completes (when all button decoration is done and the hash is normalized), re-check whether the page hash matches a modal link that wasn't opened by `init()`

Resolves: [MWPW-176753](https://jira.corp.adobe.com/browse/MWPW-176753)

## Test plan

- [ ] Navigate directly to `https://modal-video-link--da-bacom--adobecom.aem.page/drafts/jsandlan/journey#watch-video` - video modal should open immediately
- [ ] Click the watch overview CTA on that page - modal should still open as before
- [ ] Close the modal - URL hash should be cleaned up correctly
- [ ] Pages without a modal hash on load are unaffected

Test URLs:

Before: https://business.adobe.com/products/journey-optimizer.html#watch-video
After: https://modal-video-link--da-bacom--adobecom.aem.page/drafts/jsandlan/journey#watch-video