### PR TITLE
Skip eager-loading hidden hero-marquee foreground at current breakpoint

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -184,7 +184,11 @@ export const getLCPImages = (doc) => {
   if (lcpSection.nodeName === 'IMG') return [lcpSection];
   if (lcpSection.classList.contains('split')) return lcpSection.querySelectorAll('img');
   const marqueeDiv = lcpSection.firstElementChild;
-  const foregroundImg = lcpSection.querySelector(':scope > div:last-child img');
+  const fgHidden = lcpSection.classList.contains('hero-marquee') && (
+    (window.innerWidth < 600 && lcpSection.classList.contains('media-hidden-mobile'))
+    || (window.innerWidth >= 600 && window.innerWidth < 1200 && lcpSection.classList.contains('media-hidden-tablet'))
+  );
+  const foregroundImg = fgHidden ? null : lcpSection.querySelector(':scope > div:last-child img');
   if (marqueeDiv.childElementCount > 1) {
     if (window.innerWidth < 600) return [marqueeDiv.querySelector(':scope > div:first-child img') || foregroundImg];
     if (window.innerWidth >= 600 && window.innerWidth < 1200) return [marqueeDiv.querySelector(':scope > div:nth-child(2) img') || foregroundImg];


### PR DESCRIPTION
## What
Guards the foreground fallback in `getLCPImages` so a `hero-marquee` foreground that is hidden at the active breakpoint (`media-hidden-mobile` / `media-hidden-tablet`) is never hinted as the LCP image.

## Why
`getLCPImages` falls back to the foreground image when no breakpoint-specific background exists. If the foreground is hidden for the current viewport, that fallback could eager-load an image that is never rendered — wasting bandwidth and supplying a wrong `fetchpriority` hint.

## How
```js
const fgHidden = lcpSection.classList.contains('hero-marquee') && (
  (window.innerWidth < 600 && lcpSection.classList.contains('media-hidden-mobile'))
  || (window.innerWidth >= 600 && window.innerWidth < 1200 && lcpSection.classList.contains('media-hidden-tablet'))
);
const foregroundImg = fgHidden ? null : lcpSection.querySelector(':scope > div:last-child img');
```
Strictly narrowing — the existing breakpoint background paths are unchanged; only the hidden-foreground fallback now no-ops.

## Context
Adopts the visibility-aware pattern from [adobecom/cc#407](https://github.com/adobecom/cc/pull/407), per discussion [adobecom/milo-private#374](https://github.com/orgs/adobecom/discussions/374). Breakpoint-aware background selection (cc#346) was already present; MEP marquee replacement (cc#345) does not apply to bacom (eager attributes are set before `loadArea`/MEP).

## Test
- Full unit suite passes locally (335 passed, 0 failed).
- Validate on a `hero-marquee` page using `media-hidden-mobile`/`media-hidden-tablet` with no breakpoint background, across mobile/tablet/desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)