### PR TITLE
MWPW-194828: Fix open redirect in workfront-login subdomain field

### DIFF
--- a/blocks/workfront-login/workfront-login.js
+++ b/blocks/workfront-login/workfront-login.js
@@ -75,6 +75,12 @@ export async function createSubdomainForm(createTag, replaceKey, config) {
       return;
     }
 
+    if (!/^[a-zA-Z0-9-]{1,63}$/.test(input.value)) {
+      window.lana?.log(`Invalid workfront subdomain submission: ${input.value}`, { severity: 'error', tags: 'workfront-login' });
+      showError(await replaceKey('invalid-subdomain', config));
+      return;
+    }
+
     const controller = new AbortController();
     setTimeout(() => controller.abort(), 4500);
 

--- a/test/blocks/workfront-login/workfront.test.js
+++ b/test/blocks/workfront-login/workfront.test.js
@@ -101,6 +101,43 @@ describe('Workfront Login', () => {
       const error = await waitForElement('.error-wrapper.show');
       expect(error).to.exist;
     });
+
+    it('blocks open redirect attempts, logs to lana, and does not fetch', async () => {
+      fetch.resetHistory();
+      window.lana = { log: sinon.stub() };
+
+      const form = await createSubdomainForm(createTag, replaceKey, config);
+      document.querySelector('.workfront-login').append(form);
+
+      const maliciousInputs = [
+        'evil.com/',
+        'evil.com#',
+        'evil.com?',
+        'evil.com\\',
+        'evil.com@adobe',
+      ];
+
+      const button = document.querySelector('button');
+      const input = document.querySelector('input');
+
+      await maliciousInputs.reduce(async (prev, value) => {
+        await prev;
+        input.value = value;
+        input.removeAttribute('disabled');
+        button.click();
+        await delay(10);
+
+        const error = await waitForElement('.error-wrapper.show');
+        expect(error, `expected error for input "${value}"`).to.exist;
+        expect(error.querySelector('.error-text').textContent).to.equal('invalid subdomain');
+      }, Promise.resolve());
+
+      expect(fetch.called).is.false;
+      expect(window.lana.log.callCount).to.equal(maliciousInputs.length);
+      expect(window.lana.log.firstCall.args[1]).to.deep.equal({ severity: 'error', tags: 'workfront-login' });
+
+      delete window.lana;
+    });
   });
 
   describe('Proof Form', () => {


### PR DESCRIPTION
## Summary
- Validates the subdomain input against an allowlist of valid DNS label characters (`[a-zA-Z0-9-]{1,63}`) before building the redirect URL, closing an open redirect: unescaped `/`, `?`, `#`, `@`, or `\` in the input could break out of the intended `*.my.workfront.com` host and redirect users to an attacker-controlled domain.
- Logs rejected/invalid submissions to lana (`severity: error`, `tags: workfront-login`) so we can monitor the volume of invalid or malicious attempts via Splunk.

## Test URL
- Before: https://main--da-bacom--adobecom.aem.live/products/workfront/login 
- After: https://login-vuln--da-bacom--adobecom.aem.live/products/workfront/login

## Test plan
- [x] Added unit test covering `evil.com/`, `evil.com#`, `evil.com?`, `evil.com\`, `evil.com@adobe` — asserts the error state shows and `fetch`/redirect never fire.
- [x] Added assertion that `window.lana.log` is called once per invalid submission with the expected severity/tags.
- [x] `npm run test` (full suite, 336 tests) passes.
- [x] `npm run lint` passes.
- [ ] Add the `invalid-subdomain` placeholder key (with copy) to the placeholders sheet for each locale — `replaceKey` resolves it at runtime and it isn't stored in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)