### PR TITLE
feat(event-speakers): hydrate speakers from event metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,21 @@ export default function createMyBlockHydrator(repeatTemplate) {
 ```
 
 Register it in `registerEventHydrators` (`scripts/scripts.js`), which runs at page startup
-before `decorateEvent`. Two constraints, both load-bearing:
+before `decorateEvent`. Source files here carry no comments — nothing is minified, so
+comments ship to the browser — which makes this section where these constraints are
+recorded. All are load-bearing:
 
 - **The hydrator must be synchronous.** Milo does not await `decorateArea` for fragments
   or personalization, so any asynchrony races the block's `init()`. event-libs'
-  `registerHydrator` rejects async functions.
-- **Gate on metadata, not the DOM.** Blocks authored inside a fragment are not in the
-  document yet at registration time.
-
-`repeatTemplate` is injected rather than imported because `scripts.js` owns the
-runtime-resolved event-libs URL. Return its result so a bail-out isn't marked hydrated and
-can be retried on a later pass.
+  `registerHydrator` rejects async functions outright.
+- **Gate the import on metadata, not the DOM.** A `querySelector` check looks like the
+  obvious guard but is wrong: Milo resolves fragments in `decorateSection` during
+  `loadArea`, so a block authored inside a fragment is not in the document yet when
+  `registerEventHydrators` runs. Page metadata always is.
+- **Return `repeatTemplate`'s result.** event-libs marks a block `data-hydrated` only when
+  the hydrator does not return `false`, so passing the value through is what lets a block
+  whose data was not ready be retried on a later pass.
+- **`repeatTemplate` is injected, not imported**, because `scripts.js` owns the
+  runtime-resolved event-libs URL — a static import of it is not possible.
 
 Full reference: [event-libs `docs/block-hydration.md`](https://github.com/adobecom/event-libs/blob/main/docs/block-hydration.md).

--- a/README.md
+++ b/README.md
@@ -79,3 +79,51 @@ window.lana.log('message', { severity: 'warning', tags: 'block-name' });
 ```
 
 More info: https://wiki.corp.adobe.com/display/WCMSOps/Best+Practices
+
+## Event Block Hydration
+
+Blocks on event pages can be filled from event metadata instead of being authored
+speaker-by-speaker. `event-speakers` uses this today.
+
+The author writes **one** template row containing `[[speakers.field]]` placeholders plus
+any static text. event-libs clones that row per speaker and resolves the placeholders in
+its normal decoration pass, so no rendered content originates in code:
+
+| event-speakers (hydrate, speaker) | | | |
+| --- | --- | --- | --- |
+| *(image, alt =* `[[speakers.photo]]`*)* | `[[speakers.firstName]] [[speakers.lastName]]`<br>`[[speakers.title]]` | `[[speakers.bio]]` | Read more |
+
+Placeholders are written without an index — event-libs adds it per clone. Type variants
+are `speaker`, `judge`, `host`, `keynote`; omit one to render every speaker.
+
+### Adding a hydrator for another block
+
+A hydrator lives beside its block here, because bacom owns its blocks' DOM — event-libs
+provides only the mechanism. It decides *which* items render and in what order, nothing
+more:
+
+```js
+// blocks/my-block/my-block.hydrator.js
+export function selectItems(items, block) {
+  return items.filter((item) => block.classList.contains(item.kind));
+}
+
+export default function createMyBlockHydrator(repeatTemplate) {
+  return (block) => repeatTemplate(block, { selectItems });
+}
+```
+
+Register it in `registerEventHydrators` (`scripts/scripts.js`), which runs at page startup
+before `decorateEvent`. Two constraints, both load-bearing:
+
+- **The hydrator must be synchronous.** Milo does not await `decorateArea` for fragments
+  or personalization, so any asynchrony races the block's `init()`. event-libs'
+  `registerHydrator` rejects async functions.
+- **Gate on metadata, not the DOM.** Blocks authored inside a fragment are not in the
+  document yet at registration time.
+
+`repeatTemplate` is injected rather than imported because `scripts.js` owns the
+runtime-resolved event-libs URL. Return its result so a bail-out isn't marked hydrated and
+can be retried on a later pass.
+
+Full reference: [event-libs `docs/block-hydration.md`](https://github.com/adobecom/event-libs/blob/main/docs/block-hydration.md).

--- a/blocks/event-speakers/event-speakers.hydrator.js
+++ b/blocks/event-speakers/event-speakers.hydrator.js
@@ -1,5 +1,3 @@
-// Selects which speakers the event-speakers block renders, and in what order.
-// Content comes from the authored template, never from here. See README.md.
 const TYPE_KEYWORDS = ['speaker', 'judge', 'host', 'keynote'];
 
 export function selectSpeakers(speakers, block) {
@@ -12,7 +10,6 @@ export function selectSpeakers(speakers, block) {
     })
     : [...speakers];
 
-  // Speakers without an ordinal sort last
   return filtered.sort((a, b) => {
     const aHas = a.ordinal != null;
     const bHas = b.ordinal != null;
@@ -23,8 +20,6 @@ export function selectSpeakers(speakers, block) {
   });
 }
 
-// repeatTemplate is injected, not imported: scripts.js owns the event-libs URL.
-// The hydrator must stay sync, and returns the result so a bail-out can be retried.
 export default function createEventSpeakersHydrator(repeatTemplate) {
   return function hydrateEventSpeakers(block) {
     return repeatTemplate(block, { selectItems: selectSpeakers });

--- a/blocks/event-speakers/event-speakers.hydrator.js
+++ b/blocks/event-speakers/event-speakers.hydrator.js
@@ -1,15 +1,5 @@
-/**
- * Hydrator for the event-speakers block, driven by event-libs' `speakers` metadata.
- *
- * All content is authored: the author writes one template row of [[speakers.*]]
- * placeholders plus any static text (the "Read more" label included), and event-libs
- * clones that row per speaker and resolves the placeholders. This file only decides
- * which speakers appear and in what order.
- *
- * Registered from scripts.js before decorateEvent. The returned hydrator must stay
- * synchronous — registerHydrator rejects async functions, because Milo does not await
- * decorateArea for fragments or personalization.
- */
+// Selects which speakers the event-speakers block renders, and in what order.
+// Content comes from the authored template, never from here. See README.md.
 const TYPE_KEYWORDS = ['speaker', 'judge', 'host', 'keynote'];
 
 export function selectSpeakers(speakers, block) {
@@ -22,7 +12,7 @@ export function selectSpeakers(speakers, block) {
     })
     : [...speakers];
 
-  // Speakers without an ordinal sort last, preserving their authored order.
+  // Speakers without an ordinal sort last
   return filtered.sort((a, b) => {
     const aHas = a.ordinal != null;
     const bHas = b.ordinal != null;
@@ -33,15 +23,9 @@ export function selectSpeakers(speakers, block) {
   });
 }
 
-/**
- * Builds the hydrator. `repeatTemplate` is injected rather than imported so this module
- * stays free of a circular dependency on scripts.js, which owns the event-libs URL.
- * @param {Function} repeatTemplate event-libs' repeatTemplate, from its libs.js
- * @returns {(block: HTMLElement) => void} A synchronous hydrator
- */
+// repeatTemplate is injected, not imported: scripts.js owns the event-libs URL.
+// The hydrator must stay sync, and returns the result so a bail-out can be retried.
 export default function createEventSpeakersHydrator(repeatTemplate) {
-  // Returning the result lets event-libs skip marking the block hydrated when we bailed
-  // out, so a later fragment or personalization pass can retry.
   return function hydrateEventSpeakers(block) {
     return repeatTemplate(block, { selectItems: selectSpeakers });
   };

--- a/blocks/event-speakers/event-speakers.hydrator.js
+++ b/blocks/event-speakers/event-speakers.hydrator.js
@@ -1,0 +1,46 @@
+/**
+ * Hydrator for the event-speakers block, driven by event-libs' `speakers` metadata.
+ *
+ * All content is authored: the author writes one template row of [[speakers.*]]
+ * placeholders plus any static text (the "Read more" label included), and event-libs
+ * clones that row per speaker and resolves the placeholders. This file only decides
+ * which speakers appear and in what order.
+ *
+ * Registered from scripts.js before decorateEvent. The returned hydrator must stay
+ * synchronous — registerHydrator rejects async functions, because Milo does not await
+ * decorateArea for fragments or personalization.
+ */
+const TYPE_KEYWORDS = ['speaker', 'judge', 'host', 'keynote'];
+
+export function selectSpeakers(speakers, block) {
+  const type = TYPE_KEYWORDS.find((keyword) => block.classList.contains(keyword)) ?? null;
+
+  const filtered = type
+    ? speakers.filter((speaker) => {
+      const speakerType = speaker.speakerType || speaker.type;
+      return (speakerType || '').toString().toLowerCase() === type;
+    })
+    : [...speakers];
+
+  // Speakers without an ordinal sort last, preserving their authored order.
+  return filtered.sort((a, b) => {
+    const aHas = a.ordinal != null;
+    const bHas = b.ordinal != null;
+    if (aHas && bHas) return a.ordinal - b.ordinal;
+    if (aHas) return -1;
+    if (bHas) return 1;
+    return 0;
+  });
+}
+
+/**
+ * Builds the hydrator. `repeatTemplate` is injected rather than imported so this module
+ * stays free of a circular dependency on scripts.js, which owns the event-libs URL.
+ * @param {Function} repeatTemplate event-libs' repeatTemplate, from its libs.js
+ * @returns {(block: HTMLElement) => void} A synchronous hydrator
+ */
+export default function createEventSpeakersHydrator(repeatTemplate) {
+  return function hydrateEventSpeakers(block) {
+    repeatTemplate(block, { selectItems: selectSpeakers });
+  };
+}

--- a/blocks/event-speakers/event-speakers.hydrator.js
+++ b/blocks/event-speakers/event-speakers.hydrator.js
@@ -40,7 +40,9 @@ export function selectSpeakers(speakers, block) {
  * @returns {(block: HTMLElement) => void} A synchronous hydrator
  */
 export default function createEventSpeakersHydrator(repeatTemplate) {
+  // Returning the result lets event-libs skip marking the block hydrated when we bailed
+  // out, so a later fragment or personalization pass can retry.
   return function hydrateEventSpeakers(block) {
-    repeatTemplate(block, { selectItems: selectSpeakers });
+    return repeatTemplate(block, { selectItems: selectSpeakers });
   };
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -289,9 +289,16 @@ export async function loadPage() {
   if (eventMD) {
     try {
       eventUtils = await import(`${EVENT_LIBS}/libs.js`);
-      await registerEventHydrators(eventUtils);
     } catch (e) {
       eventsError = [`Could not import event-libs. ${e}`, { tags: 'event-libs' }];
+    }
+
+    // Separate catch: event-libs imported fine, so a failure here is ours and must not
+    // be reported against event-libs. Hydration is optional — the page still works.
+    try {
+      await registerEventHydrators(eventUtils);
+    } catch (e) {
+      eventsError = [`Could not register event hydrators. ${e}`, { tags: 'event-libs' }];
     }
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -262,17 +262,13 @@ export const EVENT_LIBS = (() => {
 
 let eventsError;
 
-/**
- * Registers hydrators for bacom-owned blocks that event-libs fills from event metadata.
- * Hydrators live beside their blocks here because bacom owns those blocks' DOM; event-libs
- * only provides the mechanism. Must run before decorateEvent, which is where hydration
- * happens — awaiting the import is safe here, at page startup, but would not be inside
- * decorateEvent. One registration covers the document, fragment, and personalization
- * hydration passes.
- * @param {object} eventUtils The imported event-libs libs.js
- */
-export async function registerEventHydrators(eventUtils) {
+// Registers hydrators for bacom blocks that event-libs fills from event metadata.
+// Must run before decorateEvent. See README.md#event-block-hydration.
+export async function registerEventHydrators(eventUtils, getMetadata) {
   if (!eventUtils?.registerHydrator || !eventUtils?.repeatTemplate) return;
+  // Gate on the data, not the DOM: blocks authored inside a fragment aren't in the
+  // document yet at this point, but page metadata always is.
+  if (!getMetadata('speakers')) return;
 
   const { default: createEventSpeakersHydrator } = await import('../blocks/event-speakers/event-speakers.hydrator.js');
   eventUtils.registerHydrator('event-speakers', createEventSpeakersHydrator(eventUtils.repeatTemplate));
@@ -293,10 +289,8 @@ export async function loadPage() {
       eventsError = [`Could not import event-libs. ${e}`, { tags: 'event-libs' }];
     }
 
-    // Separate catch: event-libs imported fine, so a failure here is ours and must not
-    // be reported against event-libs. Hydration is optional — the page still works.
     try {
-      await registerEventHydrators(eventUtils);
+      await registerEventHydrators(eventUtils, getMetadata);
     } catch (e) {
       eventsError = [`Could not register event hydrators. ${e}`, { tags: 'event-libs' }];
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -262,12 +262,8 @@ export const EVENT_LIBS = (() => {
 
 let eventsError;
 
-// Registers hydrators for bacom blocks that event-libs fills from event metadata.
-// Must run before decorateEvent. See README.md#event-block-hydration.
 export async function registerEventHydrators(eventUtils, getMetadata) {
   if (!eventUtils?.registerHydrator || !eventUtils?.repeatTemplate) return;
-  // Gate on the data, not the DOM: blocks authored inside a fragment aren't in the
-  // document yet at this point, but page metadata always is.
   if (!getMetadata('speakers')) return;
 
   const { default: createEventSpeakersHydrator } = await import('../blocks/event-speakers/event-speakers.hydrator.js');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -262,6 +262,22 @@ export const EVENT_LIBS = (() => {
 
 let eventsError;
 
+/**
+ * Registers hydrators for bacom-owned blocks that event-libs fills from event metadata.
+ * Hydrators live beside their blocks here because bacom owns those blocks' DOM; event-libs
+ * only provides the mechanism. Must run before decorateEvent, which is where hydration
+ * happens — awaiting the import is safe here, at page startup, but would not be inside
+ * decorateEvent. One registration covers the document, fragment, and personalization
+ * hydration passes.
+ * @param {object} eventUtils The imported event-libs libs.js
+ */
+export async function registerEventHydrators(eventUtils) {
+  if (!eventUtils?.registerHydrator || !eventUtils?.repeatTemplate) return;
+
+  const { default: createEventSpeakersHydrator } = await import('../blocks/event-speakers/event-speakers.hydrator.js');
+  eventUtils.registerHydrator('event-speakers', createEventSpeakersHydrator(eventUtils.repeatTemplate));
+}
+
 export async function loadPage() {
   const {
     loadArea, loadLana, setConfig, getConfig, createTag, getMetadata, getLocale, MILO_EVENTS,
@@ -273,6 +289,7 @@ export async function loadPage() {
   if (eventMD) {
     try {
       eventUtils = await import(`${EVENT_LIBS}/libs.js`);
+      await registerEventHydrators(eventUtils);
     } catch (e) {
       eventsError = [`Could not import event-libs. ${e}`, { tags: 'event-libs' }];
     }

--- a/test/blocks/event-speakers/event-speakers.hydrator.test.js
+++ b/test/blocks/event-speakers/event-speakers.hydrator.test.js
@@ -59,6 +59,32 @@ describe('Event Speakers hydrator', () => {
       expect(selectSpeakers(SPEAKERS, blockWith('keynote'))).to.have.lengthOf(0);
     });
 
+    it('uses the first matching keyword when a block carries two type variants', () => {
+      const data = [
+        { ordinal: 0, speakerType: 'Speaker', firstName: 'A', lastName: 'Speaker' },
+        { ordinal: 0, speakerType: 'Keynote', firstName: 'B', lastName: 'Keynote' },
+      ];
+
+      // Documented precedence: TYPE_KEYWORDS order wins, not authoring order
+      expect(names(selectSpeakers(data, blockWith('keynote speaker')))).to.deep.equal(['A Speaker']);
+    });
+
+    it('falls through to type when speakerType is an empty string', () => {
+      const data = [{ ordinal: 0, speakerType: '', type: 'Host', firstName: 'Alex', lastName: 'Chen' }];
+
+      expect(names(selectSpeakers(data, blockWith('host')))).to.deep.equal(['Alex Chen']);
+    });
+
+    it('treats an explicitly null ordinal as unordered', () => {
+      const data = [
+        { ordinal: null, speakerType: 'Speaker', firstName: 'Null', lastName: 'Ordinal' },
+        { ordinal: 3, speakerType: 'Speaker', firstName: 'Three', lastName: 'X' },
+      ];
+
+      expect(names(selectSpeakers(data, blockWith('speaker'))))
+        .to.deep.equal(['Three X', 'Null Ordinal']);
+    });
+
     it('skips speakers with no type when the block filters by one', () => {
       const data = [{ ordinal: 0, firstName: 'Untyped', lastName: 'Person' }];
 
@@ -99,8 +125,29 @@ describe('Event Speakers hydrator', () => {
     it('produces a synchronous hydrator, as registerHydrator requires', () => {
       const hydrate = createEventSpeakersHydrator(() => {});
 
+      // An async hydrator is rejected by registerHydrator, since Milo does not await
+      // decorateArea — see event-libs' hydrate.js
       expect(hydrate.constructor.name).to.equal('Function');
-      expect(hydrate(blockWith('speaker'))).to.equal(undefined);
+    });
+
+    it('passes through repeatTemplate\'s result so a bail-out is not marked hydrated', () => {
+      expect(createEventSpeakersHydrator(() => false)(blockWith('speaker'))).to.be.false;
+      expect(createEventSpeakersHydrator(() => true)(blockWith('speaker'))).to.be.true;
+    });
+
+    it('drives a stand-in repeatTemplate through the real selection rule', () => {
+      // Mirrors event-libs' contract: selectItems(items, block) -> items to render
+      const fakeRepeatTemplate = (block, { selectItems }) => {
+        const items = JSON.parse(block.dataset.items);
+        block.dataset.rendered = selectItems(items, block).map((i) => i.firstName).join(',');
+        return true;
+      };
+      const block = blockWith('judge');
+      block.dataset.items = JSON.stringify(SPEAKERS);
+
+      createEventSpeakersHydrator(fakeRepeatTemplate)(block);
+
+      expect(block.dataset.rendered).to.equal('Sam');
     });
   });
 });

--- a/test/blocks/event-speakers/event-speakers.hydrator.test.js
+++ b/test/blocks/event-speakers/event-speakers.hydrator.test.js
@@ -1,0 +1,106 @@
+import { expect } from '@esm-bundle/chai';
+import createEventSpeakersHydrator, { selectSpeakers } from '../../../blocks/event-speakers/event-speakers.hydrator.js';
+
+const SPEAKERS = [
+  { speakerId: 'spk-2', ordinal: 1, speakerType: 'Speaker', firstName: 'Katie', lastName: 'Johnson' },
+  { speakerId: 'spk-1', ordinal: 0, speakerType: 'Speaker', firstName: 'Elise', lastName: 'Swopes' },
+  { speakerId: 'jdg-1', ordinal: 0, speakerType: 'Judge', firstName: 'Sam', lastName: 'Rivera' },
+];
+
+const blockWith = (variants = '') => {
+  document.body.innerHTML = `<div class="event-speakers hydrate${variants ? ` ${variants}` : ''}"></div>`;
+  return document.querySelector('.event-speakers');
+};
+
+const names = (speakers) => speakers.map((s) => `${s.firstName} ${s.lastName}`);
+
+describe('Event Speakers hydrator', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  describe('selectSpeakers', () => {
+    it('filters by the block type variant', () => {
+      expect(names(selectSpeakers(SPEAKERS, blockWith('judge')))).to.deep.equal(['Sam Rivera']);
+    });
+
+    it('returns every speaker when no type variant is present', () => {
+      expect(selectSpeakers(SPEAKERS, blockWith())).to.have.lengthOf(3);
+    });
+
+    it('sorts by ordinal', () => {
+      expect(names(selectSpeakers(SPEAKERS, blockWith('speaker'))))
+        .to.deep.equal(['Elise Swopes', 'Katie Johnson']);
+    });
+
+    it('places speakers without an ordinal last', () => {
+      const data = [
+        { speakerType: 'Speaker', firstName: 'No', lastName: 'Ordinal' },
+        { ordinal: 5, speakerType: 'Speaker', firstName: 'Five', lastName: 'X' },
+      ];
+
+      expect(names(selectSpeakers(data, blockWith('speaker'))))
+        .to.deep.equal(['Five X', 'No Ordinal']);
+    });
+
+    it('tolerates type as an alias for speakerType', () => {
+      const data = [{ ordinal: 0, type: 'Host', firstName: 'Alex', lastName: 'Chen' }];
+
+      expect(names(selectSpeakers(data, blockWith('host')))).to.deep.equal(['Alex Chen']);
+    });
+
+    it('matches type case-insensitively', () => {
+      const data = [{ ordinal: 0, speakerType: 'KEYNOTE', firstName: 'Loud', lastName: 'Case' }];
+
+      expect(selectSpeakers(data, blockWith('keynote'))).to.have.lengthOf(1);
+    });
+
+    it('returns nothing when no speaker matches the variant', () => {
+      expect(selectSpeakers(SPEAKERS, blockWith('keynote'))).to.have.lengthOf(0);
+    });
+
+    it('skips speakers with no type when the block filters by one', () => {
+      const data = [{ ordinal: 0, firstName: 'Untyped', lastName: 'Person' }];
+
+      expect(selectSpeakers(data, blockWith('speaker'))).to.have.lengthOf(0);
+    });
+
+    it('does not mutate or reorder the source array', () => {
+      const data = [...SPEAKERS];
+      selectSpeakers(data, blockWith('speaker'));
+
+      expect(data).to.deep.equal(SPEAKERS);
+    });
+
+    it('returns the original item objects so their indexes stay recoverable', () => {
+      const selected = selectSpeakers(SPEAKERS, blockWith('speaker'));
+
+      // event-libs' repeatTemplate uses indexOf to build [[speakers:i.field]]
+      expect(SPEAKERS.indexOf(selected[0])).to.equal(1);
+      expect(SPEAKERS.indexOf(selected[1])).to.equal(0);
+    });
+  });
+
+  describe('createEventSpeakersHydrator', () => {
+    it('delegates to repeatTemplate with the selection rule', () => {
+      const calls = [];
+      const hydrate = createEventSpeakersHydrator((block, options) => {
+        calls.push({ block, options });
+      });
+      const block = blockWith('speaker');
+
+      hydrate(block);
+
+      expect(calls).to.have.lengthOf(1);
+      expect(calls[0].block).to.equal(block);
+      expect(calls[0].options.selectItems).to.equal(selectSpeakers);
+    });
+
+    it('produces a synchronous hydrator, as registerHydrator requires', () => {
+      const hydrate = createEventSpeakersHydrator(() => {});
+
+      expect(hydrate.constructor.name).to.equal('Function');
+      expect(hydrate(blockWith('speaker'))).to.equal(undefined);
+    });
+  });
+});

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -302,14 +302,16 @@ describe('Marketo Libs', () => {
 describe('registerEventHydrators', () => {
   // Wires bacom-owned block hydrators into event-libs. It reads registerHydrator and
   // repeatTemplate off event-libs' barrel by name, so this guards that coupling.
+  const hasSpeakers = (key) => (key === 'speakers' ? '[]' : null);
+  const noMetadata = () => null;
+
   it('registers a synchronous hydrator for event-speakers', async () => {
     const registered = [];
-    const repeatTemplate = () => true;
 
     await registerEventHydrators({
       registerHydrator: (name, hydrator) => registered.push([name, hydrator]),
-      repeatTemplate,
-    });
+      repeatTemplate: () => true,
+    }, hasSpeakers);
 
     expect(registered).to.have.lengthOf(1);
     const [name, hydrator] = registered[0];
@@ -325,7 +327,7 @@ describe('registerEventHydrators', () => {
     await registerEventHydrators({
       registerHydrator: (_name, fn) => { hydrator = fn; },
       repeatTemplate: (block, options) => { calledWith = { block, options }; return true; },
-    });
+    }, hasSpeakers);
 
     document.body.innerHTML = '<div class="event-speakers hydrate speaker"></div>';
     const block = document.querySelector('.event-speakers');
@@ -335,14 +337,25 @@ describe('registerEventHydrators', () => {
     expect(calledWith.options.selectItems).to.be.a('function');
   });
 
+  it('does not import the hydrator when the page has no speakers metadata', async () => {
+    let called = false;
+
+    await registerEventHydrators({
+      registerHydrator: () => { called = true; },
+      repeatTemplate: () => true,
+    }, noMetadata);
+
+    expect(called).to.be.false;
+  });
+
   it('does nothing when event-libs is too old to expose the hydration API', async () => {
     let called = false;
     const spy = () => { called = true; };
 
-    await registerEventHydrators(undefined);
-    await registerEventHydrators({});
-    await registerEventHydrators({ registerHydrator: spy });
-    await registerEventHydrators({ repeatTemplate: () => true });
+    await registerEventHydrators(undefined, hasSpeakers);
+    await registerEventHydrators({}, hasSpeakers);
+    await registerEventHydrators({ registerHydrator: spy }, hasSpeakers);
+    await registerEventHydrators({ repeatTemplate: () => true }, hasSpeakers);
 
     expect(called).to.be.false;
   });

--- a/test/scripts/scripts.test.js
+++ b/test/scripts/scripts.test.js
@@ -8,6 +8,7 @@ import {
   applyIswaTypography,
   injectMarqueePlayIcon,
   getMarketoLibs,
+  registerEventHydrators,
 } from '../../scripts/scripts.js';
 
 describe('Libs', () => {
@@ -295,5 +296,54 @@ describe('Marketo Libs', () => {
 
       expect(libs).to.equal(expected);
     });
+  });
+});
+
+describe('registerEventHydrators', () => {
+  // Wires bacom-owned block hydrators into event-libs. It reads registerHydrator and
+  // repeatTemplate off event-libs' barrel by name, so this guards that coupling.
+  it('registers a synchronous hydrator for event-speakers', async () => {
+    const registered = [];
+    const repeatTemplate = () => true;
+
+    await registerEventHydrators({
+      registerHydrator: (name, hydrator) => registered.push([name, hydrator]),
+      repeatTemplate,
+    });
+
+    expect(registered).to.have.lengthOf(1);
+    const [name, hydrator] = registered[0];
+    expect(name).to.equal('event-speakers');
+    expect(hydrator).to.be.a('function');
+    expect(hydrator.constructor.name).to.equal('Function');
+  });
+
+  it('passes the injected repeatTemplate through to the hydrator', async () => {
+    let calledWith = null;
+    let hydrator;
+
+    await registerEventHydrators({
+      registerHydrator: (_name, fn) => { hydrator = fn; },
+      repeatTemplate: (block, options) => { calledWith = { block, options }; return true; },
+    });
+
+    document.body.innerHTML = '<div class="event-speakers hydrate speaker"></div>';
+    const block = document.querySelector('.event-speakers');
+    hydrator(block);
+
+    expect(calledWith.block).to.equal(block);
+    expect(calledWith.options.selectItems).to.be.a('function');
+  });
+
+  it('does nothing when event-libs is too old to expose the hydration API', async () => {
+    let called = false;
+    const spy = () => { called = true; };
+
+    await registerEventHydrators(undefined);
+    await registerEventHydrators({});
+    await registerEventHydrators({ registerHydrator: spy });
+    await registerEventHydrators({ repeatTemplate: () => true });
+
+    expect(called).to.be.false;
   });
 });


### PR DESCRIPTION
Lets an author drive the `event-speakers` block from event-libs' `speakers` metadata instead of hand-entering every speaker's photo, name, title, company, and bio. **The block's own JS and CSS are unchanged.**

Resolves: [MWPW-202476](https://jira.corp.adobe.com/browse/MWPW-202476)

**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.live/?martech=off
- After: https://feat-event-speakers-hydrator--da-bacom--adobecom.aem.live/?martech=off&eventlibs=feat-hydrate-consumer-blocks

> [!IMPORTANT]
> Depends on **adobecom/event-libs#208**, which exports `registerHydrator` and `repeatTemplate`. Merge that first. Until it lands, use the `?eventlibs=feat-hydrate-consumer-blocks` param above.

## All content stays in authoring

The author writes **one** template row of `[[speakers.*]]` placeholders plus any static text — the expand label included — and event-libs clones that row per speaker and resolves the placeholders in its normal decoration pass:

| event-speakers (hydrate, speaker) | | | |
| --- | --- | --- | --- |
| *(image, alt =* `[[speakers.photo]]`*)* | `[[speakers.firstName]] [[speakers.lastName]]`<br>`[[speakers.title]]`<br>`[[speakers.company]]` | `[[speakers.bio]]` | Read more |

Placeholders are written **without** an index — event-libs adds it per clone. Images bind through the `alt` attribute, as elsewhere in event decoration. Cell order matters, since the block reads cells positionally.

Type variants: `speaker`, `judge`, `host`, `keynote` — omit to render every speaker. If two are authored, the first in that order wins. Speakers sort by `ordinal`, with unordered ones last.

⚠️ **Author cell 4.** The block falls back to a hardcoded English `'Read more'` when that cell is empty (`event-speakers.js:2`) — not translatable, not authorable. Pre-existing, but hydration makes the empty-cell path easier to reach.

## Why the hydrator lives here

bacom owns this block's DOM; event-libs owns the data and the mechanism. This was [raised in review on the event-libs PR](https://github.com/adobecom/event-libs/pull/208) — bundling it there had event-libs holding detailed knowledge of a block it doesn't own. So `event-speakers.hydrator.js` sits beside its block, and `scripts.js` registers it via `registerHydrator`.

```
blocks/event-speakers/
├── event-speakers.js               ← unchanged
└── event-speakers.hydrator.js      ← new: selection rule only
```

The hydrator contains no content and no markup — just "which speakers, in what order". Registration happens at page startup, before `decorateEvent`, where `await import` is still safe (it would not be inside `decorateEvent`, which Milo does not await).

`repeatTemplate` is **injected** rather than imported: a consumer can't statically import from `${EVENT_LIBS}/libs.js` (static paths must be literals, and that URL is resolved at runtime) and can't `await import()` inside a synchronous hydrator. Injection also keeps the hydrator unit-testable without loading Milo.

The hydrator **returns** `repeatTemplate`'s result, so event-libs skips marking the block hydrated when it bailed out — letting a block whose metadata wasn't ready be retried on the fragment or personalization pass.

## Verified against Milo

A single page-startup registration covers **all three** hydration passes. Milo invokes the configured `decorateArea` in exactly two further places — `blocks/fragment/fragment.js` and `features/personalization/personalization.js` — and the registry is module state on the event-libs instance, so it outlives the initial page load. The fragment path passes a detached `DOMParser` document; hydrators still resolve metadata there because `getMetadata` reads the main document by default. Both properties are covered by tests in the event-libs PR.

## Testing

- `npm run test` — 347 passed, 0 failed. 22 tests across the hydrator and its wiring.
- `npm run lint` — 0 errors.
- The existing `event-speakers.test.js` block tests are untouched and still pass.
- Also fixed in review: a failure importing our own hydrator module logged "Could not import event-libs", blaming the wrong repo — `eventUtils` was already assigned inside the same `try`. Separate catch now.
- Added in review: `registerEventHydrators` had zero coverage despite being the function that wires the feature up and the only place event-libs' two exports are read by name. Now covers the happy path, the injected `repeatTemplate` reaching the hydrator, and the guard for an older event-libs. Also covers `TYPE_KEYWORDS` precedence with two variants, empty-string `speakerType`, and explicit `null` ordinal.

## Not in scope

The Figma shows a **Collapse** affordance the block doesn't implement — expansion is one-way, since the handler replaces `.desc`'s innerHTML and destroys the button. The block also truncates on raw `innerHTML.slice(0, 75)` (can cut a tag mid-way), and its image cell has no `width: 100%`, so a hydrated `<img>` renders at intrinsic size. Plus the `'Read more'` fallback above. All need block changes; flagging for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
