### PR TITLE
Load ArpJS and generate a session id for correlation and tracking

### DIFF
--- a/scripts/arp.js
+++ b/scripts/arp.js
@@ -13,7 +13,7 @@ export function getArpSessionId() {
 
 export default async function loadArp({ clientId, prodEnv, loadScript }) {
   const sessionId = getArpSessionId();
-  window.arpSessionId = sessionId;
+  window.adobeArp = { ...window.adobeArp, sessionId };
 
   try {
     await loadScript(prodEnv ? PROD_SDK_URL : STAGE_SDK_URL);
@@ -37,9 +37,9 @@ export default async function loadArp({ clientId, prodEnv, loadScript }) {
     errorCallback: (message) => {
       window.lana?.log(`ArpJS vendor error: ${message}`, { tags: 'arp', severity: 'warning' });
     },
-    tokenCallback: (token) => {
-      window.arpToken = token;
-      window.dispatchEvent(new CustomEvent('arp:token', { detail: { token, sessionId } }));
+    tokenCallback: (sessionToken) => {
+      window.adobeArp = { ...window.adobeArp, sessionId, sessionToken };
+      window.dispatchEvent(new CustomEvent('adobeArp:token', { detail: { sessionId, sessionToken } }));
     },
     metadata: { source: 'da-bacom' },
   });

--- a/scripts/arp.js
+++ b/scripts/arp.js
@@ -1,0 +1,46 @@
+const PROD_SDK_URL = 'https://commerce.adobe.com/watson/watson.min.js';
+const STAGE_SDK_URL = 'https://commerce-stg.adobe.com/watson/watson.min.js';
+const SESSION_STORAGE_KEY = 'arp-sessionid';
+
+export function getArpSessionId() {
+  let sessionId = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+  if (!sessionId) {
+    sessionId = crypto.randomUUID();
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, sessionId);
+  }
+  return sessionId;
+}
+
+export default async function loadArp({ clientId, prodEnv, loadScript }) {
+  const sessionId = getArpSessionId();
+  window.arpSessionId = sessionId;
+
+  try {
+    await loadScript(prodEnv ? PROD_SDK_URL : STAGE_SDK_URL);
+  } catch (e) {
+    window.lana?.log(`Could not load ArpJS. ${e}`, { tags: 'arp', severity: 'error' });
+    return;
+  }
+
+  if (!window.WatsonSdk?.initAsync) {
+    window.lana?.log('ArpJS script loaded but WatsonSdk.initAsync is unavailable.', { tags: 'arp', severity: 'error' });
+    return;
+  }
+
+  await window.WatsonSdk.initAsync({
+    clientId,
+    sessionId,
+    prodEnv,
+    successCallback: ({ success, failure } = {}) => {
+      window.lana?.log(`ArpJS vendors loaded. success: ${success?.join(',')} failure: ${failure?.join(',')}`, { tags: 'arp', severity: 'info' });
+    },
+    errorCallback: (message) => {
+      window.lana?.log(`ArpJS vendor error: ${message}`, { tags: 'arp', severity: 'warning' });
+    },
+    tokenCallback: (token) => {
+      window.arpToken = token;
+      window.dispatchEvent(new CustomEvent('arp:token', { detail: { token, sessionId } }));
+    },
+    metadata: { source: 'da-bacom' },
+  });
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -123,6 +123,10 @@ const CONFIG = {
     version: '1.0',
     onDemand: false,
   },
+  arp: {
+    // TODO: replace with the real clientId once ARP-1280 (client config) is complete
+    clientId: 'REPLACE_WITH_ARP_1280_CLIENT_ID',
+  },
   atvCaptionsKey: 'bacom',
   uniqueSiteId: 'da-bacom',
   mepLingoCountryToRegion: {
@@ -265,6 +269,7 @@ let eventsError;
 export async function loadPage() {
   const {
     loadArea, loadLana, setConfig, getConfig, createTag, getMetadata, getLocale, MILO_EVENTS,
+    loadScript,
   } = await import(`${LIBS}/utils/utils.js`);
 
   let eventUtils;
@@ -340,6 +345,16 @@ export async function loadPage() {
     } catch (e) {
       window.lana?.log(`Could not load marketo-libs. ${e}`, { tags: 'marketo-libs', severity: 'error' });
     }
+  }
+
+  if (CONFIG.arp?.clientId) {
+    import('./arp.js').then(({ default: loadArp }) => loadArp({
+      clientId: CONFIG.arp.clientId,
+      prodEnv: getConfig().env?.name === 'prod',
+      loadScript,
+    })).catch((e) => {
+      window.lana?.log(`Could not load arp.js. ${e}`, { tags: 'arp', severity: 'error' });
+    });
   }
 
   await loadArea();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -123,10 +123,7 @@ const CONFIG = {
     version: '1.0',
     onDemand: false,
   },
-  arp: {
-    // TODO: replace with the real clientId once ARP-1280 (client config) is complete
-    clientId: 'REPLACE_WITH_ARP_1280_CLIENT_ID',
-  },
+  arp: { clientId: 'bacom' },
   atvCaptionsKey: 'bacom',
   uniqueSiteId: 'da-bacom',
   mepLingoCountryToRegion: {

--- a/test/scripts/arp.test.js
+++ b/test/scripts/arp.test.js
@@ -1,0 +1,96 @@
+import { expect } from '@esm-bundle/chai';
+import sinon from 'sinon';
+import loadArp, { getArpSessionId } from '../../scripts/arp.js';
+
+describe('getArpSessionId', () => {
+  beforeEach(() => {
+    window.sessionStorage.removeItem('arp-sessionid');
+  });
+
+  it('generates and persists a session id', () => {
+    const sessionId = getArpSessionId();
+    expect(sessionId).to.be.a('string').that.is.not.empty;
+    expect(window.sessionStorage.getItem('arp-sessionid')).to.equal(sessionId);
+  });
+
+  it('reuses the persisted session id on subsequent calls', () => {
+    const first = getArpSessionId();
+    const second = getArpSessionId();
+    expect(second).to.equal(first);
+  });
+});
+
+describe('loadArp', () => {
+  let loadScript;
+  let initAsync;
+  let lanaLog;
+
+  beforeEach(() => {
+    window.sessionStorage.removeItem('arp-sessionid');
+    delete window.arpSessionId;
+    delete window.arpToken;
+    delete window.WatsonSdk;
+
+    initAsync = sinon.stub().resolves();
+    window.WatsonSdk = { initAsync };
+    loadScript = sinon.stub().resolves();
+    lanaLog = sinon.stub();
+    window.lana = { log: lanaLog };
+  });
+
+  afterEach(() => {
+    delete window.WatsonSdk;
+    delete window.lana;
+    sinon.restore();
+  });
+
+  it('loads the production SDK url when prodEnv is true', async () => {
+    await loadArp({ clientId: 'client-1', prodEnv: true, loadScript });
+    expect(loadScript.calledWith('https://commerce.adobe.com/watson/watson.min.js')).to.be.true;
+  });
+
+  it('loads the stage SDK url when prodEnv is false', async () => {
+    await loadArp({ clientId: 'client-1', prodEnv: false, loadScript });
+    expect(loadScript.calledWith('https://commerce-stg.adobe.com/watson/watson.min.js')).to.be.true;
+  });
+
+  it('initializes WatsonSdk with the client config and exposes the session id', async () => {
+    await loadArp({ clientId: 'client-1', prodEnv: true, loadScript });
+    expect(initAsync.calledOnce).to.be.true;
+    const config = initAsync.firstCall.args[0];
+    expect(config.clientId).to.equal('client-1');
+    expect(config.prodEnv).to.be.true;
+    expect(config.sessionId).to.equal(window.arpSessionId);
+    expect(config.sessionId).to.equal(getArpSessionId());
+  });
+
+  it('stores the token and dispatches an event when tokenCallback fires', async () => {
+    const tokenSpy = sinon.stub();
+    window.addEventListener('arp:token', tokenSpy);
+
+    await loadArp({ clientId: 'client-1', prodEnv: true, loadScript });
+    const config = initAsync.firstCall.args[0];
+    config.tokenCallback('base64-token');
+
+    expect(window.arpToken).to.equal('base64-token');
+    expect(tokenSpy.calledOnce).to.be.true;
+    expect(tokenSpy.firstCall.args[0].detail.token).to.equal('base64-token');
+
+    window.removeEventListener('arp:token', tokenSpy);
+  });
+
+  it('logs and exits early when the script fails to load', async () => {
+    loadScript = sinon.stub().rejects(new Error('network error'));
+    await loadArp({ clientId: 'client-1', prodEnv: true, loadScript });
+    expect(initAsync.called).to.be.false;
+    expect(lanaLog.calledOnce).to.be.true;
+    expect(lanaLog.firstCall.args[1].severity).to.equal('error');
+  });
+
+  it('logs and exits early when WatsonSdk is unavailable after load', async () => {
+    delete window.WatsonSdk;
+    await loadArp({ clientId: 'client-1', prodEnv: true, loadScript });
+    expect(lanaLog.calledOnce).to.be.true;
+    expect(lanaLog.firstCall.args[1].severity).to.equal('error');
+  });
+});

--- a/test/scripts/arp.test.js
+++ b/test/scripts/arp.test.js
@@ -27,8 +27,7 @@ describe('loadArp', () => {
 
   beforeEach(() => {
     window.sessionStorage.removeItem('arp-sessionid');
-    delete window.arpSessionId;
-    delete window.arpToken;
+    delete window.adobeArp;
     delete window.WatsonSdk;
 
     initAsync = sinon.stub().resolves();
@@ -60,23 +59,23 @@ describe('loadArp', () => {
     const config = initAsync.firstCall.args[0];
     expect(config.clientId).to.equal('client-1');
     expect(config.prodEnv).to.be.true;
-    expect(config.sessionId).to.equal(window.arpSessionId);
+    expect(config.sessionId).to.equal(window.adobeArp.sessionId);
     expect(config.sessionId).to.equal(getArpSessionId());
   });
 
   it('stores the token and dispatches an event when tokenCallback fires', async () => {
     const tokenSpy = sinon.stub();
-    window.addEventListener('arp:token', tokenSpy);
+    window.addEventListener('adobeArp:token', tokenSpy);
 
     await loadArp({ clientId: 'client-1', prodEnv: true, loadScript });
     const config = initAsync.firstCall.args[0];
     config.tokenCallback('base64-token');
 
-    expect(window.arpToken).to.equal('base64-token');
+    expect(window.adobeArp.sessionToken).to.equal('base64-token');
     expect(tokenSpy.calledOnce).to.be.true;
-    expect(tokenSpy.firstCall.args[0].detail.token).to.equal('base64-token');
+    expect(tokenSpy.firstCall.args[0].detail.sessionToken).to.equal('base64-token');
 
-    window.removeEventListener('arp:token', tokenSpy);
+    window.removeEventListener('adobeArp:token', tokenSpy);
   });
 
   it('logs and exits early when the script fails to load', async () => {


### PR DESCRIPTION
Adds scripts/arp.js to load the Watson SDK per environment and call WatsonSdk.initAsync with a persisted session id, exposing the id and composite token globally for downstream consumers. CSP updates (Step 4 of the ARP integration guide) are pending client configuration and will follow in a separate change.

Resolves: [MWPW-200860](https://jira.corp.adobe.com/browse/MWPW-200860)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/?martech=off
- After: https://arpjs--da-bacom--adobecom.aem.live/?martech=off
