### PR TITLE
Fix DOM XSS via quick-edit param (VULN-36795)

### DIFF
--- a/scripts/quick-edit.js
+++ b/scripts/quick-edit.js
@@ -36,13 +36,23 @@ function generateSidekickPayload() {
   };
 }
 
+// AEM ref/branch names are limited to alphanumerics and hyphens. Rejecting
+// anything else stops the `quick-edit` param from smuggling a foreign host
+// (or a path on a trusted host) into the module origin (VULN-36795).
+const REF_PATTERN = /^[a-zA-Z0-9-]+$/;
+
+export function resolveOrigin(ref) {
+  if (!ref || ref === 'on') return 'https://da.live';
+  if (ref === 'local') return 'http://localhost:6456';
+  if (REF_PATTERN.test(ref)) return `https://${ref}--da-nx--adobe.aem.live`;
+  return null;
+}
+
 export default function init(payload) {
   const { search } = window.location;
   const ref = new URLSearchParams(search).get('quick-edit');
-  let origin;
-  if (ref === 'on' || !ref) origin = 'https://da.live';
-  if (ref === 'local') origin = 'http://localhost:6456';
-  if (!origin) origin = `https://${ref}--da-nx--adobe.aem.live`;
+  const origin = resolveOrigin(ref);
+  if (!origin) return;
   addImportmap();
   loadModule(origin, payload || generateSidekickPayload());
 }

--- a/test/scripts/quick-edit.test.js
+++ b/test/scripts/quick-edit.test.js
@@ -1,0 +1,37 @@
+import { expect } from '@esm-bundle/chai';
+import { resolveOrigin } from '../../scripts/quick-edit.js';
+
+describe('quick-edit resolveOrigin (input allowlist)', () => {
+  it('defaults to da.live when the ref is missing or "on"', () => {
+    expect(resolveOrigin(null)).to.equal('https://da.live');
+    expect(resolveOrigin('')).to.equal('https://da.live');
+    expect(resolveOrigin('on')).to.equal('https://da.live');
+  });
+
+  it('uses localhost for the "local" keyword', () => {
+    expect(resolveOrigin('local')).to.equal('http://localhost:6456');
+  });
+
+  it('builds an aem.live origin for a valid ref name', () => {
+    expect(resolveOrigin('my-branch')).to.equal('https://my-branch--da-nx--adobe.aem.live');
+    expect(resolveOrigin('stage')).to.equal('https://stage--da-nx--adobe.aem.live');
+  });
+
+  it('rejects a foreign host injected via the ref (VULN-36795)', () => {
+    expect(resolveOrigin('attacker.com/')).to.equal(null);
+    expect(resolveOrigin('attacker.com')).to.equal(null);
+    expect(resolveOrigin('evil.com/?x=')).to.equal(null);
+  });
+
+  it('rejects a path smuggled onto a trusted host via the ref', () => {
+    // `da.live/evil` would otherwise pass the hostname check downstream.
+    expect(resolveOrigin('da.live/evil')).to.equal(null);
+    expect(resolveOrigin('localhost/evil')).to.equal(null);
+  });
+
+  it('rejects any ref containing unsafe characters', () => {
+    ['a/b', 'a.b', 'a:b', 'a@b', 'a b', 'a\\b', '//evil', '..', 'a#b'].forEach((ref) => {
+      expect(resolveOrigin(ref), ref).to.equal(null);
+    });
+  });
+});


### PR DESCRIPTION
The `quick-edit` query param flowed unvalidated into a dynamic import() origin. A ref like `attacker.com/` turned the aem.live host suffix into a path segment, making the import host attacker-controlled and executing arbitrary JS in the business.adobe.com origin (IMS token exfil -> ATO).

resolveOrigin() now constrains the param to the `on`/`local` keywords or a strict ref allowlist (alphanumerics + hyphens), so `origin` is provably one of three trusted values before it reaches import(); anything else is rejected and quick-edit does not load. Adds unit tests covering the keywords, valid refs, the reported exploit, the trusted-host path-smuggling variant, and unsafe characters.
