### PR TITLE
MWPW-202491: Elastic variants and c2 Styles

### DIFF
--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
@@ -2,7 +2,6 @@
 /* stylelint-disable */
 
 /** main classes */
-
 html[dir="rtl"] {
   .bacom-elastic-carousel {
     & .elastic-carousel-container {
@@ -523,6 +522,16 @@ html[dir="rtl"] {
 .bacom-elastic-carousel.expand-content {
   --elastic-expand-panel-bg: var(--s2a-color-gray-75);
   --elastic-expand-panel-color: var(--s2a-color-gray-700);
+  --elastic-media-height: 316px;
+
+  .elastic-carousel-container {
+    max-width: 90%;
+    justify-self: center;
+  }
+
+  .elastic-carousel-container .elastic-carousel-item {
+    max-height: 485px;
+  }
 
   .elastic-carousel-expand-toggle {
     flex: 0 0 auto;
@@ -573,7 +582,9 @@ html[dir="rtl"] {
     flex-direction: column;
     overflow: hidden;
     border-radius: var(--s2a-border-radius-md);
-    height: 394px;
+    /* Definite height gives the panel + image a shared box to divide, so the image shrinks
+       (via the asset's flex: 1 / min-height: 0 below) rather than pushing the card taller. */
+    height: var(--elastic-media-height);
   }
 
   .elastic-carousel-item-media-asset {
@@ -621,13 +632,32 @@ html[dir="rtl"] {
   }
 }
 
-/** expand-content: hover zooms the media, card stays static (tablet up) */
+.elastic-carousel-footer-chevron {
+  width: .5em;
+  margin-inline-start: .4em;
+  vertical-align: middle;
+}
+
+html[dir="rtl"] .elastic-carousel-footer-chevron {
+  transform: scaleX(-1);
+}
+
 @media (width >= 768px) {
   .bacom-elastic-carousel.expand-content {
     .elastic-carousel-container .elastic-carousel-item {
       .elastic-carousel-item-media-asset img,
       .elastic-carousel-item-media-asset video {
         transition: transform .5s var(--paralax-easing);
+        max-height: 316px;
+        height: 100%;
+      }
+
+      .elastic-carousel-item-footer {
+        padding: 32px 24px;
+      }
+
+      .elastic-carousel-item-footer h3 {
+        margin-bottom: 0;
       }
 
       &.hovered,
@@ -658,11 +688,12 @@ html[dir="rtl"] {
     }
   }
 
-  .bacom-elastic-carousel.expand-content.limited {
+  .bacom-elastic-carousel.limited {
     .elastic-carousel-container .elastic-carousel-item {
       &.hovered,
       &:focus-visible {
-        max-width: none;
+        flex: 0 0 calc(100% / var(--limited-visible-slides, 3.25));
+        max-width: var(--limited-card-max-width);
       }
     }
   }
@@ -700,6 +731,7 @@ html[dir="rtl"] {
 
 .bacom-elastic-carousel.limited {
   --limited-visible-slides: 3.25;
+  --limited-card-max-width: 394px;
 
   .elastic-carousel-limited-controls {
     display: none;
@@ -731,7 +763,7 @@ html[dir="rtl"] {
 
       .elastic-carousel-item {
         flex: 0 0 calc(100% / var(--limited-visible-slides, 3.25));
-        max-width: none;
+        max-width: var(--limited-card-max-width);
         margin-inline: 0;
         animation: none;
       }

--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
@@ -510,3 +510,292 @@ html[dir="rtl"] {
     margin: 0 var(--stack-shrink);
   }
 }
+
+
+/** ==========================================================================
+    Variant: expand-content
+    Additive — only applies when the block also carries the `expand-content`
+    class. A per-card toggle reveals the description in a collapsible region
+    between the header and media; hover zooms the image instead of growing
+    the card. Reuses existing tokens, easing (--paralax-easing) and timing.
+    ========================================================================== */
+
+.bacom-elastic-carousel.expand-content {
+  --elastic-expand-panel-bg: var(--s2a-color-gray-75);
+  --elastic-expand-panel-color: var(--s2a-color-gray-700);
+
+  .elastic-carousel-expand-toggle {
+    flex: 0 0 auto;
+    margin-inline-start: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--s2a-spacing-32);
+    height: var(--s2a-spacing-32);
+    border-radius: var(--s2a-border-radius-8);
+    background-color: var(--s2a-color-gray-100);
+    color: var(--s2a-color-gray-1000);
+    cursor: pointer;
+    transition: background-color .2s ease, color .2s ease;
+
+    &:focus-visible {
+      outline: var(--s2a-border-width-2) solid var(--s2a-color-focus-ring-default);
+      outline-offset: var(--s2a-border-width-2);
+    }
+
+    .elastic-carousel-expand-icon {
+      width: var(--s2a-spacing-20);
+      height: var(--s2a-spacing-20);
+      display: block;
+    }
+
+    .elastic-carousel-expand-icon-minus {
+      display: none;
+    }
+
+    &[aria-expanded="true"] {
+      background-color: var(--s2a-color-gray-1000);
+      color: var(--s2a-color-gray-25);
+
+      .elastic-carousel-expand-icon-plus {
+        display: none;
+      }
+
+      .elastic-carousel-expand-icon-minus {
+        display: block;
+      }
+    }
+  }
+
+  .elastic-carousel-item-media {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: var(--s2a-border-radius-md);
+    height: 394px;
+  }
+
+  .elastic-carousel-item-media-asset {
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    border-top-right-radius: 16px;
+    border-top-left-radius: 16px;
+  }
+
+  .elastic-carousel-item-media-asset img,
+  .elastic-carousel-item-media-asset video {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+  }
+
+  .elastic-carousel-expand-content {
+    flex-shrink: 0;
+    display: grid;
+    grid-template-rows: 0fr;
+    background-color: var(--elastic-expand-panel-bg);
+    transition: grid-template-rows .5s var(--paralax-easing);
+
+    .elastic-carousel-expand-content-inner {
+      overflow: hidden;
+      min-height: 0;
+    }
+
+    p {
+      margin: 0;
+      padding: var(--s2a-spacing-md) var(--s2a-spacing-lg);
+      font-size: var(--s2a-font-size-sm);
+      line-height: var(--s2a-font-line-height-18);
+      color: var(--elastic-expand-panel-color);
+    }
+  }
+
+  .elastic-carousel-item.expanded {
+    .elastic-carousel-expand-content {
+      grid-template-rows: 1fr;
+    }
+  }
+}
+
+/** expand-content: hover zooms the media, card stays static (tablet up) */
+@media (width >= 768px) {
+  .bacom-elastic-carousel.expand-content {
+    .elastic-carousel-container .elastic-carousel-item {
+      .elastic-carousel-item-media-asset img,
+      .elastic-carousel-item-media-asset video {
+        transition: transform .5s var(--paralax-easing);
+      }
+
+      &.hovered,
+      &:focus-visible {
+        /* neutralise the base grow/darken so the card footprint is static */
+        max-width: var(--elastic-carousel-item-max-width);
+        width: var(--elastic-carousel-item-max-width);
+        background-color: var(--s2a-color-gray-75);
+
+        .elastic-carousel-item-header p,
+        .elastic-carousel-item-footer p {
+          color: var(--s2a-color-gray-1000);
+        }
+
+        .elastic-carousel-item-footer :is(h1, h2, h3, h4, h5, h6) {
+          color: inherit;
+        }
+
+        .elastic-carousel-item-footer:after {
+          opacity: 0;
+        }
+
+        .elastic-carousel-item-media-asset img,
+        .elastic-carousel-item-media-asset video {
+          transform: scale(1.2);
+        }
+      }
+    }
+  }
+
+  .bacom-elastic-carousel.expand-content.limited {
+    .elastic-carousel-container .elastic-carousel-item {
+      &.hovered,
+      &:focus-visible {
+        max-width: none;
+      }
+    }
+  }
+}
+
+@media (width < 768px) {
+  .bacom-elastic-carousel:is(.expand-content, .limited) {
+    .elastic-carousel-container .elastic-carousel-item {
+      color: var(--s2a-color-gray-1000);
+
+      .elastic-carousel-item-container {
+        background-color: var(--s2a-color-gray-75);
+
+        .elastic-carousel-item-header {
+          p {
+            color: var(--s2a-color-gray-1000);
+          }
+
+          &:after {
+            background-color: var(--s2a-color-gray-1000);
+          }
+        }
+      }
+    }
+  }
+
+  .bacom-elastic-carousel.expand-content
+    .elastic-carousel-container
+    .elastic-carousel-item
+    .elastic-carousel-item-container
+    .elastic-carousel-item-header:after {
+    display: none;
+  }
+}
+
+.bacom-elastic-carousel.limited {
+  --limited-visible-slides: 3.25;
+
+  .elastic-carousel-limited-controls {
+    display: none;
+  }
+}
+
+@media (width >= 768px) {
+  .bacom-elastic-carousel.limited {
+    height: auto;
+    max-width: var(--grid-max-width-default);
+    margin-inline: auto;
+    padding-inline: var(--grid-margin-width);
+    overflow: visible;
+
+    .elastic-carousel-viewport {
+      position: relative;
+      overflow: hidden;
+    }
+
+    .elastic-carousel-container {
+      position: relative;
+      left: 0;
+      width: 100%;
+      max-width: none;
+      column-gap: var(--s2a-spacing-md);
+      transform: translateX(var(--limited-offset, 0px));
+      transition: transform .5s var(--paralax-easing);
+      animation: none;
+
+      .elastic-carousel-item {
+        flex: 0 0 calc(100% / var(--limited-visible-slides, 3.25));
+        max-width: none;
+        margin-inline: 0;
+        animation: none;
+      }
+    }
+
+    .elastic-carousel-limited-controls {
+      display: flex;
+      justify-content: flex-end;
+      gap: var(--s2a-spacing-12);
+      margin-block-start: var(--s2a-spacing-lg);
+    }
+
+    &.limited-static .elastic-carousel-limited-controls {
+      display: none;
+    }
+  }
+}
+
+@media (768px <= width < 1280px) {
+  .bacom-elastic-carousel.limited {
+    --limited-visible-slides: 2.25;
+  }
+}
+
+.elastic-carousel-limited-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--s2a-spacing-2xl);
+  height: var(--s2a-spacing-2xl);
+  border: none;
+  border-radius: var(--s2a-border-radius-round);
+  background-color: var(--s2a-color-gray-25);
+  color: var(--s2a-color-gray-1000);
+  cursor: pointer;
+  transition: background-color .2s ease, color .2s ease;
+
+  .elastic-carousel-limited-icon {
+    width: var(--s2a-spacing-20);
+    height: var(--s2a-spacing-20);
+  }
+
+  &.prev .elastic-carousel-limited-icon {
+    transform: scaleX(-1);
+  }
+
+  &:disabled {
+    background-color: var(--s2a-color-gray-1000);
+    color: var(--s2a-color-gray-600);
+    cursor: default;
+  }
+
+  &:focus-visible {
+    outline: var(--s2a-border-width-2) solid var(--s2a-color-focus-ring-default);
+    outline-offset: var(--s2a-border-width-2);
+  }
+}
+
+html[dir="rtl"] .elastic-carousel-limited-control {
+  &.prev .elastic-carousel-limited-icon {
+    transform: scaleX(1);
+  }
+
+  &.next .elastic-carousel-limited-icon {
+    transform: scaleX(-1);
+  }
+}

--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.js
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.js
@@ -31,6 +31,13 @@ const CAROUSEL_ARROW_ICON = `
     <path d="M4 10h12M11 5l5 5-5 5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
   </svg>`;
 
+// Trailing chevron for the footer heading CTA (path/geometry from the Figma design). Uses
+// currentColor so it always matches the heading text.
+const FOOTER_CHEVRON_ICON = `
+  <svg class="elastic-carousel-footer-chevron" viewBox="0 0 4.5 7.5" aria-hidden="true" focusable="false">
+    <path d="M0.75 6.75L3.75 3.75L0.75 0.75" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+  </svg>`;
+
 const getCarouselName = (link) => link?.innerText?.split('|')?.[1]?.trim() || 'Adobe slides';
 
 const stopRewind = (video) => {
@@ -298,6 +305,11 @@ const decorateExpandContent = (carousel) => {
   carousel.querySelectorAll('.elastic-carousel-item').forEach(decorateExpandSlide);
 };
 
+const decorateFooterChevron = (carousel) => {
+  carousel.querySelectorAll('.elastic-carousel-item-footer :is(h1, h2, h3, h4, h5, h6)')
+    .forEach((heading) => heading.insertAdjacentHTML('beforeend', FOOTER_CHEVRON_ICON));
+};
+
 // Fewest cards. Guessed 2 for tablet.
 const LIMITED_MIN_VISIBLE = 2;
 
@@ -413,7 +425,10 @@ export default async function init(el) {
 
   const decoratedCarousel = decorateCarousel(el);
   decorateExpandContent(decoratedCarousel);
-  if (isVariant(decoratedCarousel)) decorateMobileStack(decoratedCarousel);
+  if (isVariant(decoratedCarousel)) {
+    decorateMobileStack(decoratedCarousel);
+    decorateFooterChevron(decoratedCarousel);
+  }
   const limitedController = decorateLimitedCarousel(decoratedCarousel);
   upgradeVideoPreload(decoratedCarousel);
   const scrollController = disableHoverOnScroll(decoratedCarousel);

--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.js
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.js
@@ -15,6 +15,22 @@ const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
 const isRtl = () => document.documentElement.getAttribute('dir') === 'rtl';
 const isMobile = () => window.innerWidth <= 768;
 
+// Inline icons for the expand-content variant (kept in JS to avoid extra network requests).
+const EXPAND_PLUS_ICON = `
+  <svg class="elastic-carousel-expand-icon elastic-carousel-expand-icon-plus" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+    <path d="M10 4.5v11M4.5 10h11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+  </svg>`;
+const EXPAND_MINUS_ICON = `
+  <svg class="elastic-carousel-expand-icon elastic-carousel-expand-icon-minus" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+    <circle cx="10" cy="10" r="7.25" fill="none" stroke="currentColor" stroke-width="1.5" />
+    <path d="M6.5 10h7" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+  </svg>`;
+
+const CAROUSEL_ARROW_ICON = `
+  <svg class="elastic-carousel-limited-icon" viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+    <path d="M4 10h12M11 5l5 5-5 5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+  </svg>`;
+
 const getCarouselName = (link) => link?.innerText?.split('|')?.[1]?.trim() || 'Adobe slides';
 
 const stopRewind = (video) => {
@@ -102,8 +118,14 @@ const disableHoverOnScroll = (carousel) => {
   return controller;
 };
 
+const isVariant = (carousel) => !!carousel
+  && (carousel.classList.contains('expand-content') || carousel.classList.contains('limited'));
+
 const onSlideLeave = (event) => {
-  const video = event?.target?.querySelector('video');
+  const slide = event.currentTarget;
+  if (isVariant(slide?.closest('.bacom-elastic-carousel'))) slide.classList.remove('hovered');
+
+  const video = slide?.querySelector('video');
   if (!video) return;
 
   clearTimeout(slideLeaveTimeouts.get(video));
@@ -198,7 +220,7 @@ const buildSlide = ({ slide, index, slidesTotal }) => {
         ${heading?.outerHTML}
       </div>
       <div class='elastic-carousel-item-media'>
-        ${asset.outerHTML}
+        <div class='elastic-carousel-item-media-asset'>${asset.outerHTML}</div>
       </div>
       <div class='elastic-carousel-item-footer'>
         ${linkName?.outerHTML}
@@ -229,6 +251,128 @@ const buildSlide = ({ slide, index, slidesTotal }) => {
   slideEl.addEventListener('mouseenter', onHover);
   slideEl.addEventListener('focus', onHover);
   return slideEl;
+};
+
+const toggleExpandContent = (event) => {
+  // The card itself is an anchor; keep the toggle from navigating the card.
+  event.preventDefault();
+  event.stopPropagation();
+  const toggle = event.currentTarget;
+  const item = toggle.closest('.elastic-carousel-item');
+  const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+  toggle.setAttribute('aria-expanded', String(!isExpanded));
+  item?.classList.toggle('expanded', !isExpanded);
+};
+
+const onToggleKeydown = (event) => {
+  if (event.key !== 'Enter' && event.key !== ' ' && event.key !== 'Spacebar') return;
+  toggleExpandContent(event);
+};
+
+const decorateExpandSlide = (item) => {
+  const header = item.querySelector('.elastic-carousel-item-header');
+  const media = item.querySelector('.elastic-carousel-item-media');
+  const description = item.querySelector('.elastic-carousel-item-footer p');
+  if (!header || !media || !description) return;
+
+  const regionId = `${item.querySelector('.elastic-carousel-item-container')?.id || item.dataset.index}-expand`;
+  const inner = createTag('div', { class: 'elastic-carousel-expand-content-inner' }, description);
+  const region = createTag('div', { class: 'elastic-carousel-expand-content', id: regionId }, inner);
+  media.prepend(region);
+
+  const toggle = createTag('span', {
+    class: 'elastic-carousel-expand-toggle',
+    role: 'button',
+    tabindex: '0',
+    'aria-expanded': 'false',
+    'aria-controls': regionId,
+    'aria-label': 'Toggle description',
+  }, `${EXPAND_PLUS_ICON}${EXPAND_MINUS_ICON}`);
+  toggle.addEventListener('click', toggleExpandContent);
+  toggle.addEventListener('keydown', onToggleKeydown);
+  header.append(toggle);
+};
+
+const decorateExpandContent = (carousel) => {
+  if (!carousel.classList.contains('expand-content')) return;
+  carousel.querySelectorAll('.elastic-carousel-item').forEach(decorateExpandSlide);
+};
+
+// Fewest cards. Guessed 2 for tablet.
+const LIMITED_MIN_VISIBLE = 2;
+
+const getVisibleWhole = (carousel) => {
+  const raw = parseFloat(getComputedStyle(carousel).getPropertyValue('--limited-visible-slides'));
+  return Math.max(1, Math.floor(Number.isFinite(raw) ? raw : 3));
+};
+
+const getLimitedStep = (slides) => {
+  if (slides.length < 2) return 0;
+  const [first, second] = slides;
+  return second.getBoundingClientRect().left - first.getBoundingClientRect().left;
+};
+
+// Step between adjacent cards' horizontal shrink in the mobile stack (matches the base
+// design's 3/2.25/1.5/.75/0rem ramp: a 0.75rem step).
+const STACK_SHRINK_STEP = '0.75rem';
+
+const decorateMobileStack = (carousel) => {
+  const slides = [...carousel.querySelectorAll('.elastic-carousel-item')];
+  const total = slides.length;
+  if (total < 2) return;
+  slides.forEach((slide, i) => {
+    const n = i + 1;
+    const fromEnd = total + 1 - n;
+    slide.style.zIndex = `${n}`;
+    slide.style.setProperty('--stack-contrast', `${(n - 1) / (total - 1)}`);
+    slide.style.setProperty('--stack-shrink', `calc(${total - n} * ${STACK_SHRINK_STEP})`);
+    slide.style.setProperty(
+      '--stack-offset',
+      `calc(var(--last-offset) - (var(--last-offset) / ${total} * ${fromEnd}) - var(--offset-variance-index) * ${fromEnd})`,
+    );
+  });
+};
+
+const decorateLimitedCarousel = (carousel) => {
+  if (!carousel.classList.contains('limited')) return null;
+  const container = carousel.querySelector('.elastic-carousel-container');
+  const slides = container ? [...container.querySelectorAll('.elastic-carousel-item')] : [];
+  if (!container || !slides.length) return null;
+
+  const viewport = createTag('div', { class: 'elastic-carousel-viewport' });
+  container.before(viewport);
+  viewport.append(container);
+
+  if (slides.length <= LIMITED_MIN_VISIBLE) return null;
+
+  let index = 0;
+
+  const prevBtn = createTag('button', { class: 'elastic-carousel-limited-control prev', type: 'button', 'aria-label': 'Previous cards' }, CAROUSEL_ARROW_ICON);
+  const nextBtn = createTag('button', { class: 'elastic-carousel-limited-control next', type: 'button', 'aria-label': 'Next cards' }, CAROUSEL_ARROW_ICON);
+
+  const goTo = (nextIndex) => {
+    const maxIndex = Math.max(0, slides.length - getVisibleWhole(carousel));
+    index = Math.min(maxIndex, Math.max(0, nextIndex));
+
+    const step = getLimitedStep(slides);
+    container.style.setProperty('--limited-offset', `${-1 * index * step}px`);
+    prevBtn.disabled = index <= 0;
+    nextBtn.disabled = index >= maxIndex;
+
+    carousel.classList.toggle('limited-static', maxIndex === 0);
+  };
+
+  prevBtn.addEventListener('click', () => goTo(index - 1));
+  nextBtn.addEventListener('click', () => goTo(index + 1));
+  goTo(0);
+
+  const controls = createTag('div', { class: 'elastic-carousel-limited-controls' });
+  controls.append(prevBtn, nextBtn);
+  carousel.append(controls);
+
+  const controller = new AbortController();
+  window.addEventListener('resize', () => goTo(index), { signal: controller.signal });
+  return controller;
 };
 
 const decorateCarousel = (carousel) => {
@@ -268,6 +412,9 @@ export default async function init(el) {
   ({ processTrackingLabels } = await import(`${LIBS}/martech/attributes.js`));
 
   const decoratedCarousel = decorateCarousel(el);
+  decorateExpandContent(decoratedCarousel);
+  if (isVariant(decoratedCarousel)) decorateMobileStack(decoratedCarousel);
+  const limitedController = decorateLimitedCarousel(decoratedCarousel);
   upgradeVideoPreload(decoratedCarousel);
   const scrollController = disableHoverOnScroll(decoratedCarousel);
   decoratedCarousel.querySelector('.elastic-carousel-container')?.addEventListener('mouseleave', onCarouselLeave);
@@ -276,6 +423,7 @@ export default async function init(el) {
   new MutationObserver((_, observer) => {
     if (!document.contains(el)) {
       scrollController.abort();
+      limitedController?.abort();
       mobileObservers.forEach((o) => o.disconnect());
       observer.disconnect();
     }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -205,6 +205,8 @@ export const LIBS = setLibs(window.location);
 
 (function loadStyles() {
   const paths = [`${LIBS}/styles/styles.css`];
+  const c2 = document.querySelector('meta[name="foundation"');
+  if (c2) STYLES.push('/styles/styles-c2.css');
   if (STYLES) {
     paths.push(...(Array.isArray(STYLES) ? STYLES : [STYLES]));
   }

--- a/styles/styles-c2.css
+++ b/styles/styles-c2.css
@@ -1,0 +1,1582 @@
+/* stylelint-disable selector-class-pattern, selector-id-pattern, alpha-value-notation, comment-empty-line-before, custom-property-empty-line-before, custom-property-pattern, declaration-empty-line-before, length-zero-no-unit, no-descending-specificity, no-duplicate-selectors, property-no-unknown, property-no-vendor-prefix, rule-empty-line-before, value-keyword-case */
+@font-face {
+  font-family: 'Arial Bold Adjusted';
+  font-weight: 900;
+  size-adjust: 92%;
+  src: local('Arial Bold'), local('Arial-BoldMT'), local('ArialBold');
+}
+
+@property --grid-margin-width {
+  syntax: '<length-percentage>';
+  inherits: true;
+  initial-value: 24px;
+}
+
+@property --grid-max-width {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 1920px;
+}
+
+:root {
+  /* tokens.primitives */
+  --s2a-color-gray-25: #fff;
+  --s2a-color-gray-50: #f8f8f8;
+  --s2a-color-gray-75: #f3f3f3;
+  --s2a-color-gray-100: #e9e9e9;
+  --s2a-color-gray-200: #e1e1e1;
+  --s2a-color-gray-300: #dadada;
+  --s2a-color-gray-400: #c6c6c6;
+  --s2a-color-gray-500: #8f8f8f;
+  --s2a-color-gray-600: #717171;
+  --s2a-color-gray-700: #505050;
+  --s2a-color-gray-800: #292929;
+  --s2a-color-gray-900: #131313;
+  --s2a-color-gray-1000: #000;
+  --s2a-color-green-100: #edfcf1;
+  --s2a-color-green-200: #d7f7e1;
+  --s2a-color-green-300: #adeec5;
+  --s2a-color-green-400: #6be3a2;
+  --s2a-color-green-500: #2bd17d;
+  --s2a-color-green-600: #12b867;
+  --s2a-color-green-700: #0ba45d;
+  --s2a-color-green-800: #079355;
+  --s2a-color-green-900: #05834e;
+  --s2a-color-green-1000: #036e45;
+  --s2a-color-green-1100: #025d3c;
+  --s2a-color-green-1200: #014c34;
+  --s2a-color-green-1300: #003d2c;
+  --s2a-color-green-1400: #002e22;
+  --s2a-color-green-1500: #002119;
+  --s2a-color-green-1600: #000f0c;
+  --s2a-color-blue-100: #f5f9ff;
+  --s2a-color-blue-200: #e5f0fe;
+  --s2a-color-blue-300: #cbe2fe;
+  --s2a-color-blue-400: #accffd;
+  --s2a-color-blue-500: #8eb9fc;
+  --s2a-color-blue-600: #729efd;
+  --s2a-color-blue-700: #5d89ff;
+  --s2a-color-blue-800: #4b75ff;
+  --s2a-color-blue-900: #3b63fb;
+  --s2a-color-blue-1000: #274dea;
+  --s2a-color-blue-1100: #1d3ecf;
+  --s2a-color-blue-1200: #1532ad;
+  --s2a-color-blue-1300: #10288c;
+  --s2a-color-blue-1400: #0c1f69;
+  --s2a-color-blue-1500: #0e1843;
+  --s2a-color-blue-1600: #070b1e;
+  --s2a-color-red-100: #fff6f5;
+  --s2a-color-red-200: #ffebe8;
+  --s2a-color-red-300: #ffd6d1;
+  --s2a-color-red-400: #ffbcb4;
+  --s2a-color-red-500: #ff9d91;
+  --s2a-color-red-600: #ff7665;
+  --s2a-color-red-700: #ff513d;
+  --s2a-color-red-800: #f03823;
+  --s2a-color-red-900: #d73220;
+  --s2a-color-red-1000: #b72818;
+  --s2a-color-red-1100: #9c2113;
+  --s2a-color-red-1200: #811b0e;
+  --s2a-color-red-1300: #68150a;
+  --s2a-color-red-1400: #501006;
+  --s2a-color-red-1500: #3b0b04;
+  --s2a-color-red-1600: #1d0502;
+  --s2a-color-orange-100: #fff6e7;
+  --s2a-color-orange-200: #ffeccf;
+  --s2a-color-orange-300: #ffda9e;
+  --s2a-color-orange-400: #ffc15e;
+  --s2a-color-orange-500: #ffa213;
+  --s2a-color-orange-600: #fc7d00;
+  --s2a-color-orange-700: #e86a00;
+  --s2a-color-orange-800: #d45b00;
+  --s2a-color-orange-900: #c24e00;
+  --s2a-color-orange-1000: #a73e00;
+  --s2a-color-orange-1100: #903300;
+  --s2a-color-orange-1200: #762900;
+  --s2a-color-orange-1300: #5f2000;
+  --s2a-color-orange-1400: #491800;
+  --s2a-color-orange-1500: #341200;
+  --s2a-color-orange-1600: #190800;
+  --s2a-color-yellow-100: #fff8cc;
+  --s2a-color-yellow-200: #fff197;
+  --s2a-color-yellow-300: #ffde2c;
+  --s2a-color-yellow-400: #f5c700;
+  --s2a-color-yellow-500: #e6af00;
+  --s2a-color-yellow-600: #d29500;
+  --s2a-color-yellow-700: #c18300;
+  --s2a-color-yellow-800: #af7400;
+  --s2a-color-yellow-900: #9e6600;
+  --s2a-color-yellow-1000: #865500;
+  --s2a-color-yellow-1100: #724800;
+  --s2a-color-yellow-1200: #5d3b00;
+  --s2a-color-yellow-1300: #4b2f00;
+  --s2a-color-yellow-1400: #382300;
+  --s2a-color-yellow-1500: #281900;
+  --s2a-color-yellow-1600: #120b00;
+  --s2a-color-transparent-black-00: rgb(0 0 0 / 0);
+  --s2a-color-transparent-black-04: rgb(0 0 0 / 4%);
+  --s2a-color-transparent-black-08: rgb(0 0 0 / 8%);
+  --s2a-color-transparent-black-12: rgb(0 0 0 / 12%);
+  --s2a-color-transparent-black-16: rgb(0 0 0 / 16%);
+  --s2a-color-transparent-black-24: rgb(0 0 0 / 24%);
+  --s2a-color-transparent-black-32: rgb(0 0 0 / 32%);
+  --s2a-color-transparent-black-48: rgb(0 0 0 / 48%);
+  --s2a-color-transparent-black-64: rgb(0 0 0 / 64%);
+  --s2a-color-transparent-black-72: rgb(0 0 0 / 72%);
+  --s2a-color-transparent-black-80: rgb(0 0 0 / 80%);
+  --s2a-color-transparent-black-88: rgb(0 0 0 / 88%);
+  --s2a-color-transparent-black-96: rgb(0 0 0 / 96%);
+  --s2a-color-transparent-white-00: rgb(255 255 255 / 0);
+  --s2a-color-transparent-white-04: rgb(255 255 255 / 4%);
+  --s2a-color-transparent-white-08: rgb(255 255 255 / 8%);
+  --s2a-color-transparent-white-12: rgb(255 255 255 / 12%);
+  --s2a-color-transparent-white-16: rgb(255 255 255 / 16%);
+  --s2a-color-transparent-white-24: rgb(255 255 255 / 24%);
+  --s2a-color-transparent-white-32: rgb(255 255 255 / 32%);
+  --s2a-color-transparent-white-48: rgb(255 255 255 / 48%);
+  --s2a-color-transparent-white-64: rgb(255 255 255 / 64%);
+  --s2a-color-transparent-white-72: rgb(255 255 255 / 72%);
+  --s2a-color-transparent-white-80: rgb(255 255 255 / 80%);
+  --s2a-color-transparent-white-88: rgb(255 255 255 / 88%);
+  --s2a-color-transparent-white-96: rgb(255 255 255 / 96%);
+  --s2a-color-brand-adobe-red: #eb1000;
+  --s2a-color-brand-cc-3dar: #99e83f;
+  --s2a-color-brand-cc-il: #ff9a00;
+  --s2a-color-brand-cc-ppafx: #99f;
+  --s2a-color-brand-cc-ps: #3a18ff;
+  --s2a-border-radius-0: 0;
+  --s2a-border-radius-2: 2px;
+  --s2a-border-radius-4: 4px;
+  --s2a-border-radius-8: 8px;
+  --s2a-border-radius-12: 12px;
+  --s2a-border-radius-16: 16px;
+  --s2a-border-radius-24: 24px;
+  --s2a-border-radius-32: 32px;
+  --s2a-border-radius-999: 999px;
+  --s2a-border-width-0: 0;
+  --s2a-border-width-1: 1px;
+  --s2a-border-width-2: 2px;
+  --s2a-border-width-4: 4px;
+  --s2a-opacity-00: 0;
+  --s2a-opacity-08: 8%;
+  --s2a-opacity-16: 16%;
+  --s2a-opacity-24: 24%;
+  --s2a-opacity-32: 32%;
+  --s2a-opacity-48: 48%;
+  --s2a-opacity-64: 64%;
+  --s2a-opacity-100: 100%;
+  --s2a-shadow-level-1-x: 0;
+  --s2a-shadow-level-1-y: 1px;
+  --s2a-shadow-level-1-blur: 6px;
+  --s2a-shadow-level-1-spread: 0;
+  --s2a-shadow-level-1-color: var(--s2a-color-transparent-black-12);
+  --s2a-shadow-level-2-x: 0;
+  --s2a-shadow-level-2-y: 2px;
+  --s2a-shadow-level-2-blur: 8px;
+  --s2a-shadow-level-2-spread: 0;
+  --s2a-shadow-level-2-color: var(--s2a-color-transparent-black-16);
+  --s2a-shadow-level-3-x: 0;
+  --s2a-shadow-level-3-y: 4px;
+  --s2a-shadow-level-3-blur: 12px;
+  --s2a-shadow-level-3-spread: 0;
+  --s2a-shadow-level-3-color: var(--s2a-color-transparent-black-16);
+  --s2a-shadow-level-4-x: 0;
+  --s2a-shadow-level-4-y: 6px;
+  --s2a-shadow-level-4-blur: 16px;
+  --s2a-shadow-level-4-spread: 0;
+  --s2a-shadow-level-4-color: var(--s2a-color-transparent-black-16);
+  --s2a-spacing-0: 0;
+  --s2a-spacing-2: 2px;
+  --s2a-spacing-4: 4px;
+  --s2a-spacing-8: 8px;
+  --s2a-spacing-12: 12px;
+  --s2a-spacing-16: 16px;
+  --s2a-spacing-20: 20px;
+  --s2a-spacing-24: 24px;
+  --s2a-spacing-32: 32px;
+  --s2a-spacing-40: 40px;
+  --s2a-spacing-48: 48px;
+  --s2a-spacing-64: 64px;
+  --s2a-spacing-80: 80px;
+  --s2a-spacing-96: 96px;
+  --s2a-spacing-124: 124px;
+  --s2a-spacing-160: 160px;
+  --s2a-spacing-240: 240px;
+  --s2a-font-family-adobe-clean: "Adobe Clean";
+  --s2a-font-family-adobe-clean-display: "Adobe Clean Display";
+  --s2a-font-letter-spacing-0: 0;
+  --s2a-font-letter-spacing-neg-3_84: -3.84px;
+  --s2a-font-letter-spacing-neg-3_2: -3.2px;
+  --s2a-font-letter-spacing-neg-2_88: -2.88px;
+  --s2a-font-letter-spacing-neg-1_68: -1.68px;
+  --s2a-font-letter-spacing-neg-1_44: -1.44px;
+  --s2a-font-letter-spacing-neg-1: -1px;
+  --s2a-font-letter-spacing-neg-0_96: -0.96px;
+  --s2a-font-letter-spacing-neg-0_48: -0.48px;
+  --s2a-font-letter-spacing-neg-0_2: -0.2px;
+  --s2a-font-letter-spacing-neg-0_16: -0.16px;
+  --s2a-font-line-height-16: 16px;
+  --s2a-font-line-height-18: 18px;
+  --s2a-font-line-height-20: 20px;
+  --s2a-font-line-height-21: 21px;
+  --s2a-font-line-height-24: 24px;
+  --s2a-font-line-height-32: 32px;
+  --s2a-font-line-height-40: 40px;
+  --s2a-font-line-height-48: 48px;
+  --s2a-font-line-height-56: 56px;
+  --s2a-font-line-height-69: 69px;
+  --s2a-font-line-height-76: 76px;
+  --s2a-font-line-height-92: 92px;
+  --s2a-font-size-12: 0.75rem;
+  --s2a-font-size-14: 0.875rem;
+  --s2a-font-size-16: 1rem;
+  --s2a-font-size-18: 1.125rem;
+  --s2a-font-size-20: 1.25rem;
+  --s2a-font-size-24: 1.5rem;
+  --s2a-font-size-32: 2rem;
+  --s2a-font-size-36: 2.25rem;
+  --s2a-font-size-40: 2.5rem;
+  --s2a-font-size-48: 3rem;
+  --s2a-font-size-56: 3.5rem;
+  --s2a-font-size-64: 4rem;
+  --s2a-font-size-72: 4.5rem;
+  --s2a-font-size-80: 5rem;
+  --s2a-font-size-96: 6rem;
+  --s2a-font-weight-adobe-clean-black: 900;
+  --s2a-font-weight-adobe-clean-extrabold: 800;
+  --s2a-font-weight-adobe-clean-bold: 700;
+  --s2a-font-weight-adobe-clean-medium: 500;
+  --s2a-font-weight-adobe-clean-regular: 400;
+  --s2a-font-weight-adobe-clean-display-black: 900;
+  --s2a-blur-8: 8px;
+  --s2a-blur-16: 16px;
+  --s2a-blur-24: 24px;
+  --s2a-blur-32: 32px;
+  --s2a-blur-64: 64px;
+  --s2a-blur-128: 128px;
+
+  /* tokens.primitives.light */
+
+  /* tokens.semantic */
+  --s2a-border-radius-none: var(--s2a-border-radius-0);
+  --s2a-border-radius-2xs: var(--s2a-border-radius-2);
+  --s2a-border-radius-xs: var(--s2a-border-radius-4);
+  --s2a-border-radius-sm: var(--s2a-border-radius-8);
+  --s2a-border-radius-md: var(--s2a-border-radius-16);
+  --s2a-border-radius-lg: var(--s2a-border-radius-32);
+  --s2a-border-radius-round: var(--s2a-border-radius-999);
+  --s2a-border-width-sm: var(--s2a-border-width-1);
+  --s2a-border-width-md: var(--s2a-border-width-2);
+  --s2a-border-width-lg: var(--s2a-border-width-4);
+  --s2a-opacity-disabled: var(--s2a-opacity-48);
+  --s2a-opacity-scrim-strong: var(--s2a-opacity-64);
+  --s2a-opacity-scrim-subtle: var(--s2a-opacity-32);
+  --s2a-spacing-none: var(--s2a-spacing-0);
+  --s2a-spacing-3xs: var(--s2a-spacing-2);
+  --s2a-spacing-2xs: var(--s2a-spacing-4);
+  --s2a-spacing-xs: var(--s2a-spacing-8);
+  --s2a-spacing-sm: var(--s2a-spacing-12);
+  --s2a-spacing-md: var(--s2a-spacing-16);
+  --s2a-spacing-xl: var(--s2a-spacing-32);
+  --s2a-spacing-2xl: var(--s2a-spacing-40);
+  --s2a-spacing-lg: var(--s2a-spacing-24);
+  --s2a-spacing-3xl: var(--s2a-spacing-48);
+  --s2a-spacing-4xl: var(--s2a-spacing-64);
+  --s2a-font-family-heading: var(--s2a-font-family-adobe-clean-display);
+  --s2a-font-family-default: var(--s2a-font-family-adobe-clean);
+  --s2a-font-letter-spacing-xs: var(--s2a-font-letter-spacing-neg-3_84);
+  --s2a-font-letter-spacing-sm: var(--s2a-font-letter-spacing-neg-3_2);
+  --s2a-font-letter-spacing-md: var(--s2a-font-letter-spacing-neg-2_88);
+  --s2a-font-letter-spacing-lg: var(--s2a-font-letter-spacing-neg-1_68);
+  --s2a-font-letter-spacing-xl: var(--s2a-font-letter-spacing-neg-1_44);
+  --s2a-font-letter-spacing-2xl: var(--s2a-font-letter-spacing-neg-1);
+  --s2a-font-letter-spacing-3xl: var(--s2a-font-letter-spacing-neg-0_96);
+  --s2a-font-letter-spacing-4xl: var(--s2a-font-letter-spacing-neg-0_48);
+  --s2a-font-letter-spacing-5xl: var(--s2a-font-letter-spacing-neg-0_2);
+  --s2a-font-letter-spacing-6xl: var(--s2a-font-letter-spacing-0);
+  --s2a-font-line-height-2xs: var(--s2a-font-line-height-16);
+  --s2a-font-line-height-xs: var(--s2a-font-line-height-18);
+  --s2a-font-line-height-sm: var(--s2a-font-line-height-20);
+  --s2a-font-line-height-md: var(--s2a-font-line-height-24);
+  --s2a-font-line-height-lg: var(--s2a-font-line-height-32);
+  --s2a-font-line-height-xl: var(--s2a-font-line-height-40);
+  --s2a-font-line-height-2xl: var(--s2a-font-line-height-48);
+  --s2a-font-line-height-3xl: var(--s2a-font-line-height-56);
+  --s2a-font-line-height-4xl: var(--s2a-font-line-height-69);
+  --s2a-font-line-height-5xl: var(--s2a-font-line-height-76);
+  --s2a-font-line-height-6xl: var(--s2a-font-line-height-92);
+  --s2a-font-size-xs: var(--s2a-font-size-12);
+  --s2a-font-size-sm: var(--s2a-font-size-14);
+  --s2a-font-size-md: var(--s2a-font-size-16);
+  --s2a-font-size-lg: var(--s2a-font-size-18);
+  --s2a-font-size-xl: var(--s2a-font-size-20);
+  --s2a-font-size-2xl: var(--s2a-font-size-24);
+  --s2a-font-size-3xl: var(--s2a-font-size-32);
+  --s2a-font-size-4xl: var(--s2a-font-size-36);
+  --s2a-font-size-5xl: var(--s2a-font-size-40);
+  --s2a-font-size-6xl: var(--s2a-font-size-48);
+  --s2a-font-size-7xl: var(--s2a-font-size-56);
+  --s2a-font-size-8xl: var(--s2a-font-size-64);
+  --s2a-font-size-9xl: var(--s2a-font-size-72);
+  --s2a-font-size-10xl: var(--s2a-font-size-80);
+  --s2a-font-size-11xl: var(--s2a-font-size-96);
+  --s2a-font-weight-heading: var(--s2a-font-weight-adobe-clean-display-black);
+  --s2a-font-weight-body: var(--s2a-font-weight-adobe-clean-regular);
+  --s2a-font-weight-eyebrow: var(--s2a-font-weight-adobe-clean-bold);
+  --s2a-font-weight-label: var(--s2a-font-weight-adobe-clean-bold);
+  --s2a-font-weight-caption: var(--s2a-font-weight-adobe-clean-bold);
+  --s2a-blur-xs: var(--s2a-blur-8);
+  --s2a-blur-sm: var(--s2a-blur-16);
+  --s2a-blur-md: var(--s2a-blur-32);
+  --s2a-blur-lg: var(--s2a-blur-64);
+  --s2a-layout-sm: var(--s2a-spacing-80);
+  --s2a-layout-md: var(--s2a-spacing-96);
+  --s2a-layout-lg: var(--s2a-spacing-124);
+  --s2a-layout-xl: var(--s2a-spacing-160);
+  --s2a-layout-2xl: var(--s2a-spacing-240);
+
+  /* tokens.semantic.light */
+  --s2a-color-background-brand: var(--s2a-color-brand-adobe-red);
+  --s2a-color-background-default: var(--s2a-color-gray-25);
+  --s2a-color-background-disabled: var(--s2a-color-gray-50);
+  --s2a-color-background-inverse: var(--s2a-color-gray-1000);
+  --s2a-color-background-knockout: var(--s2a-color-gray-1000);
+  --s2a-color-background-subtle: var(--s2a-color-gray-50);
+  --s2a-color-background-utility-error: var(--s2a-color-red-900);
+  --s2a-color-border-brand: var(--s2a-color-brand-adobe-red);
+  --s2a-color-border-default: var(--s2a-color-gray-800);
+  --s2a-color-border-disabled: var(--s2a-color-gray-400);
+  --s2a-color-border-inverse: var(--s2a-color-gray-25);
+  --s2a-color-border-knockout: var(--s2a-color-gray-1000);
+  --s2a-color-border-strong: var(--s2a-color-gray-900);
+  --s2a-color-border-subtle: var(--s2a-color-gray-300);
+  --s2a-color-border-utility-error: var(--s2a-color-red-900);
+  --s2a-color-content-body-strong: var(--s2a-color-content-strong);
+  --s2a-color-content-body-subtle: var(--s2a-color-content-subtle);
+  --s2a-color-content-brand: var(--s2a-color-brand-adobe-red);
+  --s2a-color-content-caption: var(--s2a-color-content-subtle);
+  --s2a-color-content-default: var(--s2a-color-gray-1000);
+  --s2a-color-content-disabled: var(--s2a-color-gray-400);
+  --s2a-color-content-eyebrow: var(--s2a-color-transparent-black-64);
+  --s2a-color-content-inverse: var(--s2a-color-content-knockout);
+  --s2a-color-content-knockout: var(--s2a-color-gray-25);
+  --s2a-color-content-label: var(--s2a-color-content-default);
+  --s2a-color-content-strong: var(--s2a-color-gray-900);
+  --s2a-color-content-subheading: var(--s2a-color-gray-1000);
+  --s2a-color-content-subtle: var(--s2a-color-transparent-black-64);
+  --s2a-color-content-heading: var(--s2a-color-content-default);
+  --s2a-color-content-utility-error: var(--s2a-color-red-900);
+  --s2a-color-focus-ring-default: var(--s2a-color-blue-900);
+  --s2a-color-focus-ring-knockout: var(--s2a-color-gray-25);
+
+  /* tokens.responsive.sm */
+  --s2a-viewport-vertical-padding-none: var(--s2a-spacing-none);
+  --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-md);
+  --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-lg);
+  --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-xl);
+  --s2a-viewport-vertical-padding-md: var(--s2a-spacing-2xl);
+  --s2a-viewport-vertical-padding-lg: var(--s2a-spacing-4xl);
+  --s2a-viewport-vertical-padding-xl: var(--s2a-layout-sm);
+  --s2a-layout-guide-gap: var(--s2a-spacing-xs);
+  --s2a-typography-font-size-super: var(--s2a-font-size-7xl);
+  --s2a-typography-font-size-heading-1: var(--s2a-font-size-5xl);
+  --s2a-typography-font-size-heading-2: var(--s2a-font-size-3xl);
+  --s2a-typography-font-size-heading-3: var(--s2a-font-size-2xl);
+  --s2a-typography-font-size-heading-4: var(--s2a-font-size-xl);
+  --s2a-typography-font-size-heading-5: var(--s2a-font-size-lg);
+  --s2a-typography-font-size-heading-6: var(--s2a-font-size-md);
+  --s2a-typography-font-size-body-xs: var(--s2a-font-size-xs);
+  --s2a-typography-font-size-body-sm: var(--s2a-font-size-sm);
+  --s2a-typography-font-size-body-md: var(--s2a-font-size-md);
+  --s2a-typography-font-size-body-lg: var(--s2a-font-size-md);
+  --s2a-typography-font-size-eyebrow: var(--s2a-font-size-md);
+  --s2a-typography-font-size-label: var(--s2a-font-size-sm);
+  --s2a-typography-font-size-caption: var(--s2a-font-size-xs);
+  --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-lg);
+  --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-lg);
+  --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-3xl);
+  --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-4xl);
+  --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-5xl);
+  --s2a-typography-letter-spacing-heading-6: var(--s2a-font-letter-spacing-5xl);
+  --s2a-typography-letter-spacing-body-xs: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-sm: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-md: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-body-lg: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-eyebrow: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-label: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-letter-spacing-caption: var(--s2a-font-letter-spacing-6xl);
+  --s2a-typography-line-height-super: var(--s2a-font-line-height-3xl);
+  --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-xl);
+  --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-lg);
+  --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-md);
+  --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-heading-6: var(--s2a-font-line-height-xs);
+  --s2a-typography-line-height-body-xs: var(--s2a-font-line-height-xs);
+  --s2a-typography-line-height-body-sm: var(--s2a-font-line-height-xs);
+  --s2a-typography-line-height-body-md: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-eyebrow: var(--s2a-font-line-height-sm);
+  --s2a-typography-line-height-label: var(--s2a-font-line-height-xs);
+  --s2a-typography-line-height-caption: var(--s2a-font-line-height-2xs);
+
+  /* Milo-specific declarations */
+  --scroll-padding-block: 0;
+  --body-font-family-base: var(--s2a-font-family-default), adobe-clean, "Trebuchet MS", sans-serif;
+  --body-font-family: var(--body-font-family-base);
+  --heading-font-family: "Adobe Clean Display Black", var(--s2a-font-family-heading), adobe-clean-display, "Arial Bold Adjusted", sans-serif;
+  --feds-language-banner-height: 44px;
+
+  /* Animation properties */
+  --parallax-easing: cubic-bezier(0.42, 0, 0, 1);
+
+  /* Grid sizes */
+  --grid-gutter: var(--s2a-spacing-xs);
+  --grid-columns: 6;
+  --grid-margin-width-base: var(--s2a-spacing-24);
+  --grid-margin-width-fixed: var(--s2a-spacing-24);
+  --grid-margin-width: var(--grid-margin-width-base);
+  --grid-margin-width-target: var(--grid-margin-width-base);
+  --grid-max-width-default: 1920px;
+  --grid-max-width-fluid: 2560px;
+
+  --global-height-nav: 80px;
+
+  /* Regional font variations */
+  &:lang(ar) {
+    --body-font-family: adobe-arabic, myriad-arabic, var(--body-font-family-base);
+
+    font-size: 125%;
+  }
+
+  &:lang(ko-KR),
+  &:lang(ko) {
+    --body-font-family: adobe-clean-han-korean, var(--body-font-family-base);
+    --heading-font-family: var(--body-font-family);
+
+    word-break: keep-all;
+  }
+
+  &:lang(ja-JP),
+  &:lang(ja) {
+    --body-font-family: adobe-clean-han-japanese, var(--body-font-family-base);
+    --heading-font-family: var(--body-font-family);
+  }
+
+  &:lang(zh-TW) {
+    --body-font-family: adobe-clean-han-traditional, var(--body-font-family-base);
+    --heading-font-family: var(--body-font-family);
+  }
+
+  &:lang(zh-CN) {
+    --body-font-family: adobe-clean-han-simplified-c, var(--body-font-family-base);
+    --heading-font-family: var(--body-font-family);
+  }
+
+  &:lang(zh-HK) {
+    --body-font-family: adobe-clean-han-traditional, var(--body-font-family-base);
+    --heading-font-family: var(--body-font-family);
+  }
+
+  &:lang(th) {
+    --body-font-family: adobe-clean-thai, var(--body-font-family-base);
+    --heading-font-family: var(--body-font-family);
+  }
+
+  &:lang(vi-VN),
+  &:lang(vi),
+  &:lang(he) {
+    --heading-font-family: var(--body-font-family);
+  }
+}
+
+.dark {
+  /* tokens.semantic.dark */
+  --s2a-color-background-default: var(--s2a-color-gray-900);
+  --s2a-color-background-inverse: var(--s2a-color-gray-25);
+  --s2a-color-background-subtle: var(--s2a-color-gray-700);
+  --s2a-color-border-default: var(--s2a-color-gray-300);
+  --s2a-color-border-inverse: var(--s2a-color-gray-1000);
+  --s2a-color-border-knockout: var(--s2a-color-gray-25);
+  --s2a-color-border-strong: var(--s2a-color-gray-25);
+  --s2a-color-content-default: var(--s2a-color-gray-25);
+  --s2a-color-content-eyebrow: var(--s2a-color-transparent-white-48);
+  --s2a-color-content-inverse: var(--s2a-color-gray-1000);
+  --s2a-color-content-label: var(--s2a-color-content-knockout);
+  --s2a-color-content-strong: var(--s2a-color-gray-600);
+  --s2a-color-content-subheading: var(--s2a-color-content-knockout);
+  --s2a-color-content-subtle: var(--s2a-color-transparent-white-64);
+  --s2a-color-content-heading: var(--s2a-color-content-knockout);
+  --s2a-color-focus-ring-default: var(--s2a-color-blue-500);
+
+  /* Milo-specific declarations */
+}
+
+/* TODO: Consolidate all visually hidden content that's needed for accessibility / screen readers */
+sr-only, .sr-only, .feds-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+html {
+  scroll-padding-block: var(--scroll-padding-block);
+}
+
+body {
+  display: block;
+  font-family: var(--body-font-family);
+  font-size: var(--s2a-typography-font-size-body-md);
+  font-weight: var(--s2a-font-weight-body);
+  line-height: var(--s2a-typography-line-height-body-md);
+  letter-spacing: var(--s2a-typography-letter-spacing-body-md);
+  background-color: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+  margin: 0;
+  word-wrap: break-word;
+  -webkit-font-smoothing: antialiased;
+  opacity: 1 !important; /* Fix Target hiding */
+
+  &:has(footer:focus-within) {
+    #onetrust-consent-sdk:not(:has(#ot-cookie-button.show)) {
+      position: sticky;
+      bottom: 0;
+
+      /* #onetrust-banner-sdk z-index value */
+      z-index: 2147483645;
+
+      #onetrust-banner-sdk {
+        position: sticky;
+      }
+    }
+  }
+
+  &:has(.dialog-modal) #onetrust-consent-sdk {
+    display: none;
+  }
+}
+
+header.global-navigation {
+  min-height: var(--global-height-nav);
+}
+
+body:has(.global-navigation) main {
+  margin-top: calc(-1 * var(--global-height-nav));
+}
+
+main > div,
+main .section:is([data-status='decorated'], [data-status='pending']) {
+  display: none;
+}
+
+main > .section,
+.fragment > .section {
+  display: block;
+  position: relative;
+}
+
+div[data-failed="true"] {
+  border: 4px solid #ff00a0;
+  position: relative;
+  margin: 12px;
+  border-radius: 6px;
+  display: block;
+
+  &::before {
+    content: attr(data-reason);
+    color: white;
+    padding: 0 0 2px 6px;
+    background: #ff00a0;
+    font-weight: 700;
+    display: block;
+  }
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+blockquote {
+  margin: 0;
+}
+
+a {
+  color: var(--s2a-color-content-default);
+
+  &.standalone-link {
+    &::after {
+      display: inline-block;
+      margin-inline-start: var(--s2a-spacing-8);
+      content: url('../assets/img/arrow-right.svg');
+      transition: transform 0.5s var(--parallax-easing);
+    }
+
+    [dir="rtl"] &::after {
+      transform: rotate(180deg);
+    }
+
+    &:hover {
+      &::after {
+        transform: translate3d(var(--s2a-spacing-4), 0, 0);
+      }
+
+      [dir="rtl"] &::after {
+        transform: translate3d(calc(var(--s2a-spacing-4) * -1), 0, 0) rotate(180deg);
+      }
+    }
+  }
+
+  &:is(.auto-block, .fragment) {
+    display: none;
+  }
+
+  &.quiet,
+  &.quiet:is(:hover, :focus, :active) {
+    text-decoration: none;
+  }
+
+  &.static,
+  &.static:is(:hover, :focus, :active) {
+    color: var(--text-color); /* TODO: Replace with an S2A variable */
+  }
+}
+
+h1, h2, h3, h4, h5, h6, [class*="heading-"] {
+  margin: 0;
+  font-family: var(--heading-font-family);
+  font-weight: var(--s2a-font-weight-heading);
+  line-height: 100%;
+  scroll-margin-top: var(--feds-totalheight-nav); /* TODO: Replace with the eventual Gnav variable */
+
+  strong {
+    font-weight: inherit;
+  }
+
+  a,
+  a:is(:hover, :focus, :active) {
+    color: currentColor;
+  }
+}
+
+.heading-super {
+  font-size: var(--s2a-typography-font-size-super);
+  line-height: var(--s2a-typography-line-height-super);
+  letter-spacing: var(--s2a-typography-letter-spacing-super);
+}
+
+h1, .heading-1 {
+  font-size: var(--s2a-typography-font-size-heading-1);
+  line-height: var(--s2a-typography-line-height-heading-1);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-1);
+}
+
+h2, .heading-2 {
+  font-size: var(--s2a-typography-font-size-heading-2);
+  line-height: var(--s2a-typography-line-height-heading-2);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-2);
+}
+
+h3, .heading-3 {
+  font-size: var(--s2a-typography-font-size-heading-3);
+  line-height: var(--s2a-typography-line-height-heading-3);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-3);
+}
+
+h4, .heading-4 {
+  font-size: var(--s2a-typography-font-size-heading-4);
+  line-height: var(--s2a-typography-line-height-heading-4);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-4);
+}
+
+h5, .heading-5 {
+  font-size: var(--s2a-typography-font-size-heading-5);
+  line-height: var(--s2a-typography-line-height-heading-5);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-5);
+}
+
+h6, .heading-6 {
+  font-size: var(--s2a-typography-font-size-heading-6);
+  line-height: var(--s2a-typography-line-height-heading-6);
+  letter-spacing: var(--s2a-typography-letter-spacing-heading-6);
+}
+
+p {
+  margin: 0;
+}
+
+.body-lg {
+  font-size: var(--s2a-typography-font-size-body-lg);
+  line-height: var(--s2a-typography-line-height-body-lg);
+  letter-spacing: var(--s2a-typography-letter-spacing-body-lg);
+}
+
+.body-md {
+  font-size: var(--s2a-typography-font-size-body-md);
+  line-height: var(--s2a-typography-line-height-body-md);
+  letter-spacing: var(--s2a-typography-letter-spacing-body-md);
+}
+
+.body-sm {
+  font-size: var(--s2a-typography-font-size-body-sm);
+  line-height: var(--s2a-typography-line-height-body-sm);
+  letter-spacing: var(--s2a-typography-letter-spacing-body-sm);
+}
+
+.eyebrow, [class*="eyebrow-"] {
+  font-weight: var(--s2a-font-weight-eyebrow);
+  font-size: var(--s2a-typography-font-size-eyebrow);
+  line-height: var(--s2a-typography-line-height-eyebrow);
+  letter-spacing: var(--s2a-typography-letter-spacing-eyebrow);
+  color: var(--s2a-color-content-eyebrow);
+}
+
+.label, [class*="label-"] {
+  font-weight: var(--s2a-font-weight-label);
+  font-size: var(--s2a-typography-font-size-label);
+  line-height: var(--s2a-typography-line-height-label);
+  letter-spacing: var(--s2a-typography-letter-spacing-label);
+}
+
+.caption, [class*="caption-"] {
+  font-weight: var(--s2a-font-weight-caption);
+  font-size: var(--s2a-typography-font-size-caption);
+  line-height: var(--s2a-typography-line-height-caption);
+  letter-spacing: var(--s2a-typography-letter-spacing-caption);
+}
+
+.breadcrumbs {
+  display: none;
+}
+
+.spacing-none { padding-block: var(--s2a-viewport-vertical-padding-none); }
+.spacing-2xs  { padding-block: var(--s2a-viewport-vertical-padding-2xs); }
+.spacing-xs   { padding-block: var(--s2a-viewport-vertical-padding-xs); }
+.spacing-sm   { padding-block: var(--s2a-viewport-vertical-padding-sm); }
+.spacing-md   { padding-block: var(--s2a-viewport-vertical-padding-md); }
+.spacing-lg   { padding-block: var(--s2a-viewport-vertical-padding-lg); }
+.spacing-xl   { padding-block: var(--s2a-viewport-vertical-padding-xl); }
+
+.spacing-none-top { padding-top: var(--s2a-viewport-vertical-padding-none); }
+.spacing-2xs-top  { padding-top: var(--s2a-viewport-vertical-padding-2xs); }
+.spacing-xs-top   { padding-top: var(--s2a-viewport-vertical-padding-xs); }
+.spacing-sm-top   { padding-top: var(--s2a-viewport-vertical-padding-sm); }
+.spacing-md-top   { padding-top: var(--s2a-viewport-vertical-padding-md); }
+.spacing-lg-top   { padding-top: var(--s2a-viewport-vertical-padding-lg); }
+.spacing-xl-top   { padding-top: var(--s2a-viewport-vertical-padding-xl); }
+
+.spacing-none-bottom { padding-bottom: var(--s2a-viewport-vertical-padding-none); }
+.spacing-2xs-bottom  { padding-bottom: var(--s2a-viewport-vertical-padding-2xs); }
+.spacing-xs-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-xs); }
+.spacing-sm-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-sm); }
+.spacing-md-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-md); }
+.spacing-lg-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-lg); }
+.spacing-xl-bottom   { padding-bottom: var(--s2a-viewport-vertical-padding-xl); }
+
+.container {
+  --grid-max-width: var(--grid-max-width-default);
+  --grid-max-width-target: var(--grid-max-width-default);
+  --grid-content-width: var(--grid-max-width);
+  --grid-padding: max(
+    var(--grid-margin-width),
+    calc((100% - var(--grid-content-width)) / 2)
+  );
+
+  width: auto;
+  max-width: none;
+  padding-inline: var(--grid-padding);
+
+  &.fluid {
+    --grid-max-width: var(--grid-max-width-fluid);
+    --grid-margin-width: 0px; /* Keep unit for calc */
+  }
+
+  &.fixed {
+    --grid-margin-width: var(--grid-margin-width-fixed);
+    --grid-margin-width-target: var(--grid-margin-width-fixed);
+  }
+
+  .container {
+    padding-inline: 0;
+  }
+}
+
+[class*="up"] {
+  &.two-up,
+  &.three-up,
+  &.four-up,
+  &.six-up {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--grid-gutter);
+    align-items: start;
+  }
+}
+
+.section {
+  position: relative;
+
+  .section-background {
+    img {
+      object-fit: cover;
+      height: 100%;
+      width: 100%;
+    }
+  }
+}
+
+.section-anchor {
+  scroll-margin-top: var(--global-height-nav); /* TODO: Replace with correct variable */
+}
+
+.hide-block {
+  display: none !important;
+}
+
+.disable-scroll {
+  overflow: hidden;
+}
+
+.static-links a:not([class*="button"]) {
+  color: inherit;
+}
+
+.action-area {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s2a-spacing-xs);
+}
+
+.con-button {
+  --cta-backdrop-filter: blur(calc(var(--s2a-blur-md) / 2));
+  box-sizing: border-box;
+  background-color: var(--s2a-color-transparent-black-00);
+  backdrop-filter: var(--cta-backdrop-filter);
+  -webkit-backdrop-filter: var(--cta-backdrop-filter);
+  border-radius: var(--s2a-border-radius-round);
+  border: var(--s2a-border-width-md) solid var(--s2a-color-gray-1000);
+  color: var(--s2a-color-gray-1000);
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--s2a-spacing-xs);
+  font-size: var(--s2a-typography-font-size-label);
+  font-weight: var(--s2a-font-weight-adobe-clean-bold);
+  line-height: var(--s2a-typography-line-height-label);
+  letter-spacing: var(--s2a-typography-letter-spacing-label);
+  text-decoration: none;
+  height: var(--s2a-spacing-2xl);
+  padding: var(--s2a-spacing-none) var(--s2a-spacing-lg);
+  transition: background-color 300ms var(--parallax-easing),
+    border-color 300ms var(--parallax-easing),
+    color 300ms var(--parallax-easing);
+
+  &:focus-visible {
+    outline: var(--s2a-border-width-2) solid var(--s2a-color-focus-ring-default);
+    outline-offset: var(--s2a-border-width-2);
+  }
+
+  &:is(:disabled, [aria-disabled="true"], .disabled) {
+    pointer-events: none;
+    opacity: 48%;
+    cursor: not-allowed;
+  }
+
+  &.outline {
+    &:hover {
+      background-color: var(--s2a-color-transparent-black-08);
+    }
+
+    &:active {
+      background-color: var(--s2a-color-gray-1000);
+      color: var(--s2a-color-gray-25);
+    }
+  }
+
+  &.button-xs {
+    padding: var(--s2a-spacing-none) var(--s2a-spacing-sm);
+    height: var(--s2a-spacing-lg);
+  }
+
+  &.blue {
+    background-color: var(--s2a-color-blue-900);
+    border-color: var(--s2a-color-blue-900);
+    --cta-backdrop-filter: none;
+    color: var(--s2a-color-gray-25);
+
+    &:hover {
+      background-color: var(--s2a-color-blue-1000);
+      border-color: var(--s2a-color-blue-1000);
+    }
+    &:active {
+      background-color: var(--s2a-color-blue-1100);
+      border-color: var(--s2a-color-blue-1100);
+    }
+
+    &:is(:disabled, [aria-disabled="true"], .disabled) {
+      background-color: var(--s2a-color-gray-1000);
+      border-color: var(--s2a-color-gray-1000);
+    }
+  }
+
+  &.fill {
+    background-color: var(--s2a-color-gray-1000);
+    border-color: var(--s2a-color-gray-1000);
+    --cta-backdrop-filter: none;
+    color: var(--s2a-color-gray-25);
+
+    &:hover {
+      background-color: var(--s2a-color-transparent-black-64);
+      border-color: var(--s2a-color-transparent-black-64);
+    }
+
+    &:active {
+      background-color: var(--s2a-color-gray-1000);
+      border-color: var(--s2a-color-gray-1000);
+    }
+  }
+
+  &.transparent {
+    border: none;
+    --cta-backdrop-filter: none;
+
+    &:hover {
+      background-color: var(--s2a-color-transparent-black-08);
+    }
+
+    &:active {
+      background-color: var(--s2a-color-transparent-black-12);
+      color: var(--s2a-color-gray-1000);
+    }
+  }
+
+  .icon  {
+    display: flex;
+    align-items: center;
+    svg {
+      width: 12px;
+      height: 12px;
+    }
+  }
+}
+
+/* Icon Button Styles */
+.icon-button {
+  align-items: center;
+  background-color: var(--s2a-color-transparent-white-16);
+  block-size: 32px;
+  border: var(--s2a-border-width-sm) solid var(--s2a-color-transparent-white-12);
+  border-radius: 6px; /* No token */
+  box-sizing: border-box;
+  display: inline-flex;
+  flex-shrink: 0;
+  inline-size: 32px;
+  justify-content: center;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+  will-change: background-color, border-color;
+  path {
+    transition: fill 0.2s ease;
+    will-change: fill;
+  }
+}
+
+/* Promo CTA Styles */
+.promo-cta {
+  align-items: center;
+  background: var(--s2a-color-background-knockout);
+  border-radius: var(--s2a-border-radius-12);
+  color: var(--s2a-color-content-knockout);
+  display: inline-flex;
+  font-size: var(--s2a-typography-font-size-eyebrow);
+  font-weight: var(--s2a-font-weight-eyebrow);
+  gap: var(--s2a-spacing-sm);
+  letter-spacing: var(--s2a-typography-letter-spacing-eyebrow);
+  line-height: var(--s2a-typography-line-height-eyebrow);
+  padding: var(--s2a-spacing-sm);
+  text-decoration: none;
+  white-space: nowrap;
+  img {
+    block-size: 32px;
+    flex-shrink: 0;
+    inline-size: 32px;
+    object-fit: cover;
+    overflow: hidden;
+  }
+
+  .icon-button {
+    margin-inline-start: var(--s2a-spacing-sm);
+  }
+
+  &:hover,
+  &:focus {
+    .icon-button {
+      background-color: var(--s2a-color-transparent-white-24);
+    }
+  }
+
+  &:active {
+    .icon-button {
+      background-color: var(--s2a-color-content-knockout);
+      border-color: var(--s2a-color-content-knockout);
+      path {
+        fill: var(--s2a-color-background-knockout);
+      }
+    }
+  }
+}
+
+.dark {
+  .con-button {
+    &.outline {
+      background-color: var(--s2a-color-transparent-white-00);
+      border-color: var(--s2a-color-gray-25);
+
+      &:hover {
+        background-color: var(--s2a-color-transparent-white-64);
+        color: var(--s2a-color-gray-1000);
+      }
+      &:active {
+        background-color: var(--s2a-color-gray-25);
+        color: var(--s2a-color-gray-1000);
+      }
+    }
+
+    &.fill {
+      background-color: var(--s2a-color-gray-25);
+      border-color: var(--s2a-color-gray-25);
+      color: var(--s2a-color-gray-1000);
+
+      &:hover {
+        background-color: var(--s2a-color-transparent-white-64);
+      }
+
+      &:active {
+        background-color: var(--s2a-color-gray-25);
+      }
+    }
+
+    &.transparent {
+      background-color: var(--s2a-color-transparent-white-00);
+      color: var(--s2a-color-gray-25);
+
+      &:hover {
+        background-color: var(--s2a-color-transparent-white-12);
+        color: var(--s2a-color-gray-25);
+      }
+      &:active {
+        background-color: var(--s2a-color-transparent-white-16);
+        color: var(--s2a-color-gray-25);
+      }
+    }
+
+    &.blue:is(:disabled, [aria-disabled="true"], .disabled) {
+      border-color: var(--s2a-color-gray-25);
+      background-color: var(--s2a-color-gray-25);
+      color: var(--s2a-color-gray-1000);
+    }
+  }
+}
+
+span.hang-opening-quote {
+  position: absolute;
+  transform: translateX(-100%);
+}
+
+[dir="rtl"] span.hang-opening-quote {
+  transform: translateX(100%);
+}
+
+.section:has(~ .section.parallax-garage-door-reveal):not(.parallax-move-up-fast) {
+  z-index: 1;
+}
+/* TODO: Parallax styles should be loaded separately and conditionally */
+@supports (animation-timeline: view()) {
+  /* General parallax declarations */
+  [class*="parallax-"] {
+    /* Default transition values */
+    --parallax-opacity-from: 1;
+    --parallax-translate-y: 0;
+    --parallax-translate-x: 0;
+    --parallax-scale: 1;
+    --parallax-blur: 0;
+    --parallax-stagger-drift: 48px;
+
+    /* Default range values */
+    --parallax-range-start-name: entry;
+    --parallax-range-start-length: 0%;
+    --parallax-range-start: var(--parallax-range-start-name) var(--parallax-range-start-length);
+    --parallax-range-end-name: entry;
+    --parallax-range-end-length: 100%;
+    --parallax-range-end: var(--parallax-range-end-name) var(--parallax-range-end-length);
+
+    animation-name: enable-parallax;
+    animation-timing-function: var(--parallax-easing);
+    animation-fill-mode: both;
+    animation-timeline: view(block 40% 10%);
+    animation-range: var(--parallax-range-start) var(--parallax-range-end);
+
+    /* Performance optimization */
+    will-change: opacity, transform, filter;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [class*="parallax-"],
+    [class*="parallax-"] *,
+    [class*="parallax-"]::before,
+    [class*="parallax-"]::after {
+      animation: none !important;
+    }
+
+    .section.parallax-move-up-fast {
+      position: static !important;
+    }
+  }
+
+  /* Variant definitions */
+  .parallax-move-up {
+    --parallax-translate-y: 100px;
+  }
+
+  .parallax-scale-up {
+    --parallax-scale: 0.9;
+  }
+
+  /* When scaling down, check whether you need to use clipping
+    to prevent the element from exceeding the viewport */
+  .parallax-scale-down {
+    --parallax-scale: 1.1;
+  }
+
+  .parallax-blur {
+    --parallax-blur: 10px;
+  }
+
+  .parallax-opacity {
+    --parallax-opacity-from: 0;
+  }
+
+  @keyframes enable-parallax {
+    from {
+      opacity: var(--parallax-opacity-from);
+      transform: translate3d(var(--parallax-translate-x), var(--parallax-translate-y), 0)
+        scale(var(--parallax-scale));
+      filter: blur(var(--parallax-blur));
+    }
+
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale(1);
+      filter: blur(0);
+    }
+  }
+
+  /* Grid parallax declarations */
+  .parallax-scale-down-grid {
+    animation-name: enable-grid-parallax;
+    will-change: padding-inline;
+    overflow: clip;
+  }
+
+  @keyframes enable-grid-parallax {
+    from {
+      --grid-max-width: var(--grid-max-width-fluid);
+      --grid-margin-width: 0px;
+    }
+
+    to {
+      --grid-max-width: var(--grid-max-width-target);
+      --grid-margin-width: var(--grid-margin-width-target);
+    }
+  }
+
+  /* Stagger parallax declarations */
+  [class*="parallax-stagger-"] {
+    view-timeline: --parallax-stagger-timeline block;
+    view-timeline-inset: 40% 10%;
+
+    > :not([class*="section-"]) {
+      --parallax-stagger-row-index: 0;
+
+      animation-timing-function: var(--parallax-easing);
+      animation-fill-mode: both;
+      animation-timeline: --parallax-stagger-timeline;
+      animation-range: var(--parallax-range-start) var(--parallax-range-end);
+      will-change: transform;
+    }
+
+    /* Column count per -up class */
+    &.two-up { --parallax-stagger-cols: 2; }
+    &.three-up { --parallax-stagger-cols: 3; }
+    &.four-up { --parallax-stagger-cols: 4; }
+    &.six-up { --parallax-stagger-cols: 6; }
+
+    /* Column stagger indices per -up class */
+    &.two-up   > :nth-child(2n+1 of :not([class*="section-"])),
+    &.three-up > :nth-child(3n+1 of :not([class*="section-"])),
+    &.four-up  > :nth-child(4n+1 of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+1 of :not([class*="section-"])) { --parallax-stagger-index: 1.5; }
+
+    &.two-up   > :nth-child(2n of :not([class*="section-"])),
+    &.three-up > :nth-child(3n+2 of :not([class*="section-"])),
+    &.four-up  > :nth-child(4n+2 of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+2 of :not([class*="section-"])) { --parallax-stagger-index: 3.25; }
+
+    &.three-up > :nth-child(3n of :not([class*="section-"])),
+    &.four-up  > :nth-child(4n+3 of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+3 of :not([class*="section-"])) { --parallax-stagger-index: 5.5; }
+
+    &.four-up  > :nth-child(4n of :not([class*="section-"])),
+    &.six-up   > :nth-child(6n+4 of :not([class*="section-"])) { --parallax-stagger-index: 7.75; }
+
+    &.six-up   > :nth-child(6n+5 of :not([class*="section-"])) { --parallax-stagger-index: 10; }
+
+    &.six-up   > :nth-child(6n of :not([class*="section-"])) { --parallax-stagger-index: 12.25; }
+
+    /* Row stagger indices per -up class */
+    /* Row 1 */
+    &.two-up   > :nth-child(n+3 of :not([class*="section-"])):nth-child(-n+4  of :not([class*="section-"])),
+    &.three-up > :nth-child(n+4 of :not([class*="section-"])):nth-child(-n+6  of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+5 of :not([class*="section-"])):nth-child(-n+8  of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+7 of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 1;
+    }
+
+    /* Row 2 */
+    &.two-up   > :nth-child(n+5  of :not([class*="section-"])):nth-child(-n+6  of :not([class*="section-"])),
+    &.three-up > :nth-child(n+7  of :not([class*="section-"])):nth-child(-n+9  of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+9  of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+18 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 2;
+    }
+
+    /* Row 3 */
+    &.two-up   > :nth-child(n+7  of :not([class*="section-"])):nth-child(-n+8  of :not([class*="section-"])),
+    &.three-up > :nth-child(n+10 of :not([class*="section-"])):nth-child(-n+12 of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+16 of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+19 of :not([class*="section-"])):nth-child(-n+24 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 3;
+    }
+
+    /* Row 4 */
+    &.two-up   > :nth-child(n+9  of :not([class*="section-"])):nth-child(-n+10 of :not([class*="section-"])),
+    &.three-up > :nth-child(n+13 of :not([class*="section-"])):nth-child(-n+15 of :not([class*="section-"])),
+    &.four-up  > :nth-child(n+17 of :not([class*="section-"])):nth-child(-n+20 of :not([class*="section-"])),
+    &.six-up   > :nth-child(n+25 of :not([class*="section-"])):nth-child(-n+30 of :not([class*="section-"])) {
+      --parallax-stagger-row-index: 4;
+    }
+
+    @media (width >= 768px) {
+      animation-name: none;
+
+      > :not([class*="section-"]) {
+        animation-name: enable-parallax-stagger;
+      }
+
+      &.masonry-layout > :not([class*="section-"]) {
+        --parallax-stagger-drift: 150px;
+
+        animation-timeline: view(block);
+      }
+
+      /* Prolong animation for 2 rows */
+      &.two-up:has(> :nth-child(3 of :not([class*="section-"]))),
+      &.three-up:has(> :nth-child(4 of :not([class*="section-"]))),
+      &.four-up:has(> :nth-child(5 of :not([class*="section-"]))),
+      &.six-up:has(> :nth-child(7 of :not([class*="section-"]))) {
+        --parallax-range-end-name: cover;
+        --parallax-range-end-length: 70%;
+      }
+
+      /* Prolong animation for 3+ rows */
+      &.two-up:has(> :nth-child(5 of :not([class*="section-"]))),
+      &.three-up:has(> :nth-child(7 of :not([class*="section-"]))),
+      &.four-up:has(> :nth-child(9 of :not([class*="section-"]))),
+      &.six-up:has(> :nth-child(13 of :not([class*="section-"]))) {
+        --parallax-range-end-length: 80%;
+      }
+    }
+  }
+
+  .parallax-stagger-ltr > :not([class*="section-"]) {
+    --parallax-stagger-from: calc(
+      (var(--parallax-stagger-index) + var(--parallax-stagger-row-index))
+      * var(--parallax-stagger-drift)
+    );
+  }
+
+  .parallax-stagger-rtl > :not([class*="section-"]) {
+    --parallax-stagger-from: calc(
+      (var(--parallax-stagger-cols) - 1 - var(--parallax-stagger-index) + var(--parallax-stagger-row-index))
+      * var(--parallax-stagger-drift)
+    );
+  }
+
+  .parallax-stagger-ltr.masonry-layout > :not([class*="section-"]) {
+    --parallax-stagger-from: calc(var(--parallax-stagger-index) * var(--parallax-stagger-drift));
+  }
+
+  .parallax-stagger-rtl.masonry-layout > :not([class*="section-"]) {
+    --parallax-stagger-from: calc((1 - var(--parallax-stagger-index)) * var(--parallax-stagger-drift));
+  }
+
+  @keyframes enable-parallax-stagger {
+    from { transform: translate3d(0, var(--parallax-stagger-from, 0), 0); }
+    to { transform: translate3d(0, 0, 0); }
+  }
+
+  /* Garage door parallax (rich content over section w/ bkg) declarations */
+  /* TODO: decide if this is general enough to be global */
+  .section.parallax-garage-door-reveal {
+    --gd-grow-from: -50vh;
+    --gd-reveal-from: 20vh;
+
+    transform-origin: top center;
+    animation: garage-door-grow ease-out both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 36%;
+
+    @media (width >= 1280px) {
+      --gd-grow-from: -90vh;
+      --gd-reveal-from: 30vh;
+      animation-range: entry 0% cover 48%;
+    }
+
+    @media (width >= 1920px) {
+      --gd-grow-from: -70vh;
+      animation-range: entry 0% cover 36%;
+    }
+
+    .section-background {
+      overflow: hidden;
+
+      img {
+        animation: garage-door-bg-scale ease-out both;
+        animation-timeline: view();
+        animation-range: entry 0% cover 70%;
+      }
+    }
+
+    .foreground {
+      z-index: 1;
+      position: relative;
+      animation: garage-door-reveal ease-out both;
+      animation-timeline: view();
+      animation-range: cover -10% cover 70%;
+
+      * {
+        animation: garage-door-line-height ease-out both;
+        animation-timeline: view();
+        animation-range: entry 30% cover 60%;
+      }
+    }
+  }
+
+  @keyframes garage-door-grow {
+    from { transform: translateY(var(--gd-grow-from)); }
+    to { transform: translateY(0); }
+  }
+
+  @keyframes garage-door-reveal {
+    from { transform: translateY(var(--gd-reveal-from)); }
+  }
+
+  @keyframes garage-door-bg-scale {
+    from { transform: scale(1); }
+    to { transform: scale(1.1); }
+  }
+
+  @keyframes garage-door-line-height {
+    from { line-height: 60%; }
+  }
+
+  /* Section 1 to section 2 parallax declarations */
+  /* TODO: decide if this is general enough to be a global class */
+  .section.parallax-move-up-fast {
+    --parallax-move-up-to: -35vh;
+
+    will-change: transform;
+    position: sticky;
+    top: 0;
+    z-index: 0;
+    animation-name: parallax-move-up-fast;
+    animation-timeline: scroll(root block);
+    animation-range: var(--feds-promo-bar-height, 0px) calc(var(--feds-promo-bar-height, 0px) + 80vh);
+    animation-timing-function: ease-out;
+
+    /* Shorter viewports in the common laptop width band need more travel */
+    @media (width >= 1280px) and (width < 1440px) and (height < 900px) {
+      --parallax-move-up-to: -50vh;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: black;
+      opacity: 0;
+      pointer-events: none;
+      animation: parallax-fade-to-dark linear both;
+      animation-timeline: scroll(root block);
+      animation-range: var(--feds-promo-bar-height, 0px) calc(var(--feds-promo-bar-height, 0px) + 80vh);
+      z-index: 2;
+    }
+  }
+
+  @keyframes parallax-move-up-fast {
+    from { transform: translateY(0); }
+    to { transform: translateY(var(--parallax-move-up-to)); }
+  }
+
+  @keyframes parallax-fade-to-dark {
+    from { opacity: 0; }
+    to { opacity: 0.75; }
+  }
+
+  .section:has(+ .section.parallax-double-garage-door),
+  .section:has(+ .section:has(.parallax-double-garage-door)) {
+    z-index: 2;
+  }
+
+  .section:is(.parallax-double-garage-door, :has(.parallax-double-garage-door)) {
+    overflow: clip;
+    animation: dg-top-door ease-out both, dg-exit ease-out both;
+    animation-timeline: view(), view();
+    animation-range: entry 0% entry 70%, exit 40% exit 90%;
+    animation-composition: replace, add;
+  }
+
+  @keyframes dg-top-door {
+    from { transform: translateY(-30vh); }
+    to { transform: translateY(0); }
+  }
+
+  @keyframes dg-exit {
+    from { transform: translateY(0); }
+    to { transform: translateY(20vh); }
+  }
+}
+
+.dark {
+  background-color: var(--s2a-color-background-default);
+  color: var(--s2a-color-content-default);
+
+  a {
+    color: var(--link-color-dark); /* TODO: Replace with an S2A variable */
+
+    &.static,
+    &.static:is(:hover, :focus, :active) {
+      color: var(--color-white); /* TODO: Replace with an S2A variable */
+    }
+  }
+}
+
+.language-banner {
+  height: var(--feds-language-banner-height);
+  visibility: hidden;
+}
+
+@media (width >= 768px) {
+  :root {
+    /* Grid definitions */
+    --grid-columns: 12;
+    --grid-margin-width-base: 8.333%;
+  }
+
+  .container {
+    --grid-width-6: calc(var(--grid-max-width) * 6 / var(--grid-columns));
+    --grid-width-8: calc(var(--grid-max-width) * 8 / var(--grid-columns));
+    --grid-width-10: calc(var(--grid-max-width) * 10 / var(--grid-columns));
+  }
+
+  [class*="up"] {
+    &.two-up {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+
+      &.fill-last-row > :nth-child(odd of :not([class*="section-"])):not(:has(~ :not([class*="section-"]))) {
+        grid-column: 1 / -1;
+      }
+    }
+
+    &.three-up { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    &.four-up { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    &.six-up { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+  }
+}
+
+@media (width >= 1024px) {
+  :root {
+    /* tokens.responsive.md */
+    --s2a-viewport-vertical-padding-2xs: var(--s2a-spacing-xl);
+    --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-2xl);
+    --s2a-viewport-vertical-padding-sm: var(--s2a-spacing-4xl);
+    --s2a-viewport-vertical-padding-md: var(--s2a-layout-sm);
+    --s2a-viewport-vertical-padding-lg: var(--s2a-layout-lg);
+    --s2a-viewport-vertical-padding-xl: var(--s2a-layout-xl);
+    --s2a-typography-font-size-super: var(--s2a-font-size-9xl);
+    --s2a-typography-font-size-heading-1: var(--s2a-font-size-7xl);
+    --s2a-typography-font-size-heading-2: var(--s2a-font-size-6xl);
+    --s2a-typography-font-size-heading-3: var(--s2a-font-size-3xl);
+    --s2a-typography-font-size-heading-4: var(--s2a-font-size-2xl);
+    --s2a-typography-font-size-heading-5: var(--s2a-font-size-xl);
+    --s2a-typography-font-size-body-xs: var(--s2a-font-size-sm);
+    --s2a-typography-font-size-body-lg: var(--s2a-font-size-lg);
+    --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-md);
+    --s2a-typography-letter-spacing-heading-1: var(--s2a-font-letter-spacing-sm);
+    --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-xl);
+    --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
+    --s2a-typography-line-height-super: var(--s2a-font-line-height-4xl);
+    --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-3xl);
+    --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-2xl);
+    --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-lg);
+    --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-md);
+    --s2a-typography-line-height-body-lg: var(--s2a-font-line-height-md);
+  }
+}
+
+@media (width >= 1280px) {
+  :root {
+    /* tokens.responsive.lg */
+    --s2a-viewport-vertical-padding-xs: var(--s2a-spacing-4xl);
+    --s2a-viewport-vertical-padding-sm: var(--s2a-layout-sm);
+    --s2a-viewport-vertical-padding-md: var(--s2a-layout-lg);
+    --s2a-viewport-vertical-padding-lg: var(--s2a-layout-xl);
+    --s2a-viewport-vertical-padding-xl: var(--s2a-layout-2xl);
+    --s2a-typography-font-size-super: var(--s2a-font-size-11xl);
+    --s2a-typography-font-size-heading-1: var(--s2a-font-size-10xl);
+    --s2a-typography-font-size-heading-2: var(--s2a-font-size-7xl);
+    --s2a-typography-font-size-heading-3: var(--s2a-font-size-6xl);
+    --s2a-typography-font-size-heading-4: var(--s2a-font-size-4xl);
+    --s2a-typography-font-size-heading-5: var(--s2a-font-size-2xl);
+    --s2a-typography-font-size-heading-6: var(--s2a-font-size-lg);
+    --s2a-typography-font-size-body-lg: var(--s2a-font-size-xl);
+    --s2a-typography-letter-spacing-super: var(--s2a-font-letter-spacing-xs);
+    --s2a-typography-letter-spacing-heading-2: var(--s2a-font-letter-spacing-lg);
+    --s2a-typography-letter-spacing-heading-3: var(--s2a-font-letter-spacing-xl);
+    --s2a-typography-letter-spacing-heading-4: var(--s2a-font-letter-spacing-2xl);
+    --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-3xl);
+    --s2a-typography-line-height-super: var(--s2a-font-line-height-6xl);
+    --s2a-typography-line-height-heading-1: var(--s2a-font-line-height-5xl);
+    --s2a-typography-line-height-heading-2: var(--s2a-font-line-height-3xl);
+    --s2a-typography-line-height-heading-3: var(--s2a-font-line-height-2xl);
+    --s2a-typography-line-height-heading-4: var(--s2a-font-line-height-lg);
+    --s2a-typography-line-height-heading-5: var(--s2a-font-line-height-md);
+  }
+}
+
+@media (width >= 1440px) {
+  :root {
+    /* tokens.responsive.xl */
+    --s2a-typography-letter-spacing-heading-5: var(--s2a-font-letter-spacing-4xl);
+  }
+
+  .section:is(.parallax-double-garage-door, :has(.parallax-double-garage-door)) {
+    animation-range: entry 0% entry 70%, exit 50% exit 90%;
+  }
+}

--- a/test/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
+++ b/test/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
@@ -33,6 +33,7 @@ describe('bacom-elastic-carousel', () => {
       expect(el.querySelector('.elastic-carousel-viewport')).to.be.null;
       expect(el.querySelector('.elastic-carousel-limited-controls')).to.be.null;
       expect(el.querySelector('.elastic-carousel-expand-toggle')).to.be.null;
+      expect(el.querySelector('.elastic-carousel-footer-chevron')).to.be.null;
     });
   });
 
@@ -76,6 +77,18 @@ describe('bacom-elastic-carousel', () => {
       const panel = el.querySelector('.elastic-carousel-expand-content .elastic-carousel-expand-content-inner');
       expect(panel).to.exist;
       expect(panel.textContent).to.contain('Description text for card 0');
+    });
+
+    it('appends the CTA chevron inside each footer heading', async () => {
+      const el = buildBlock(3, 'expand-content');
+      await init(el);
+      const headings = [...el.querySelectorAll('.elastic-carousel-item-footer h3')];
+      expect(headings.length).to.equal(3);
+      headings.forEach((h) => {
+        const chevron = h.querySelector('svg.elastic-carousel-footer-chevron');
+        expect(chevron).to.exist;
+        expect(chevron).to.equal(h.lastElementChild); // trails the text
+      });
     });
   });
 

--- a/test/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
+++ b/test/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
@@ -1,0 +1,145 @@
+import { expect } from '@esm-bundle/chai';
+import init from '../../../blocks/bacom-elastic-carousel/bacom-elastic-carousel.js';
+
+// Builds the authored (pre-block-decoration) markup: a block with `count` slides, each slide a
+// div with a left column (icon img, eyebrow, heading, description, cta link) and a right column
+// (picture asset + media link) — the shape buildSlide() expects.
+const buildBlock = (count, variantClasses = '') => {
+  const slides = Array.from({ length: count }, (_, i) => `
+    <div>
+      <div>
+        <p><img alt="icon ${i}"></p>
+        <p>Eyebrow ${i}</p>
+        <h3 id="heading-${i}">Heading ${i}</h3>
+        <p>Description text for card ${i}.</p>
+        <p><a href="https://example.com/card-${i}">Card ${i} | Adobe slides</a></p>
+      </div>
+      <div>
+        <picture><img alt="media ${i}"></picture>
+        <a href="https://example.com/media-${i}.mp4">media ${i}</a>
+      </div>
+    </div>`).join('');
+  document.body.innerHTML = `<div class="bacom-elastic-carousel ${variantClasses}">${slides}</div>`;
+  return document.querySelector('.bacom-elastic-carousel');
+};
+
+describe('bacom-elastic-carousel', () => {
+  describe('base (no variant)', () => {
+    it('decorates slides without variant scaffolding', async () => {
+      const el = buildBlock(4);
+      await init(el);
+      expect(el.querySelectorAll('.elastic-carousel-item').length).to.equal(4);
+      // additive guarantee: variant-only nodes must not appear on a plain carousel
+      expect(el.querySelector('.elastic-carousel-viewport')).to.be.null;
+      expect(el.querySelector('.elastic-carousel-limited-controls')).to.be.null;
+      expect(el.querySelector('.elastic-carousel-expand-toggle')).to.be.null;
+    });
+  });
+
+  describe('expand-content', () => {
+    it('adds a toggle per card and expands/collapses independently', async () => {
+      const el = buildBlock(3, 'expand-content');
+      await init(el);
+
+      const toggles = el.querySelectorAll('.elastic-carousel-expand-toggle');
+      expect(toggles.length).to.equal(3);
+      toggles.forEach((t) => expect(t.getAttribute('aria-expanded')).to.equal('false'));
+
+      const [first, second] = [...el.querySelectorAll('.elastic-carousel-item')];
+      const firstToggle = first.querySelector('.elastic-carousel-expand-toggle');
+
+      firstToggle.click();
+      expect(firstToggle.getAttribute('aria-expanded')).to.equal('true');
+      expect(first.classList.contains('expanded')).to.be.true;
+      // per-card: the second card stays collapsed
+      expect(second.classList.contains('expanded')).to.be.false;
+
+      firstToggle.click();
+      expect(firstToggle.getAttribute('aria-expanded')).to.equal('false');
+      expect(first.classList.contains('expanded')).to.be.false;
+    });
+
+    it('toggle click does not navigate the card link', async () => {
+      const el = buildBlock(3, 'expand-content');
+      await init(el);
+      const item = el.querySelector('.elastic-carousel-item');
+      let navigated = false;
+      item.addEventListener('click', (e) => { navigated = true; e.preventDefault(); });
+      item.querySelector('.elastic-carousel-expand-toggle').click();
+      // stopPropagation keeps the click from reaching the anchor
+      expect(navigated).to.be.false;
+    });
+
+    it('moves the description into the expandable panel', async () => {
+      const el = buildBlock(1, 'expand-content');
+      await init(el);
+      const panel = el.querySelector('.elastic-carousel-expand-content .elastic-carousel-expand-content-inner');
+      expect(panel).to.exist;
+      expect(panel.textContent).to.contain('Description text for card 0');
+    });
+  });
+
+  describe('limited', () => {
+    it('wraps the row in a clipping viewport and renders paging controls', async () => {
+      const el = buildBlock(8, 'limited');
+      const controller = await init(el);
+
+      const viewport = el.querySelector('.elastic-carousel-viewport');
+      expect(viewport).to.exist;
+      expect(viewport.querySelector('.elastic-carousel-container')).to.exist;
+
+      const controls = el.querySelector('.elastic-carousel-limited-controls');
+      expect(controls).to.exist;
+      expect(controls.querySelector('.elastic-carousel-limited-control.prev')).to.exist;
+      expect(controls.querySelector('.elastic-carousel-limited-control.next')).to.exist;
+
+      controller?.abort?.();
+    });
+
+    // Layout-independent state machine. Without the block CSS the visible count falls back to 3,
+    // so 8 slides -> last index 5. (The per-breakpoint pixel paging is covered by e2e.)
+    it('advances and clamps the prev/next disabled state at the ends', async () => {
+      const el = buildBlock(8, 'limited');
+      const controller = await init(el);
+      const prev = el.querySelector('.elastic-carousel-limited-control.prev');
+      const next = el.querySelector('.elastic-carousel-limited-control.next');
+
+      expect(prev.disabled).to.be.true; // start
+      expect(next.disabled).to.be.false;
+
+      next.click();
+      expect(prev.disabled).to.be.false; // advanced off the start
+
+      for (let i = 0; i < 8; i += 1) next.click(); // page past the end; clamps
+      expect(next.disabled).to.be.true; // reached the last page
+      expect(prev.disabled).to.be.false;
+
+      for (let i = 0; i < 8; i += 1) prev.click(); // back to the start; clamps
+      expect(prev.disabled).to.be.true;
+      expect(next.disabled).to.be.false;
+
+      controller?.abort?.();
+    });
+
+    it('hides controls when there is nothing to page (<= 2 slides)', async () => {
+      const el = buildBlock(2, 'limited');
+      await init(el);
+      // viewport still wraps, but no controls since 2 cards never overflow at any breakpoint
+      expect(el.querySelector('.elastic-carousel-viewport')).to.exist;
+      expect(el.querySelector('.elastic-carousel-limited-controls')).to.be.null;
+    });
+  });
+
+  describe('mobile stack (variant, > 5 cards)', () => {
+    it('assigns an increasing z-index and stack vars to every card', async () => {
+      const el = buildBlock(8, 'expand-content');
+      await init(el);
+      const items = [...el.querySelectorAll('.elastic-carousel-item')];
+      // base CSS only covers nth-child(1..5); the 6th+ must be generalized in JS
+      expect(items[5].style.zIndex).to.equal('6');
+      expect(items[7].style.zIndex).to.equal('8');
+      expect(items[5].style.getPropertyValue('--stack-offset')).to.not.equal('');
+      expect(items[5].style.getPropertyValue('--stack-contrast')).to.not.equal('');
+    });
+  });
+});


### PR DESCRIPTION
* Adds two variants to the bacom-elastic-carousel: 
   * "limited" will add the carousel portion and the carousel controls
   * "expand-content" will provide the card styling for the open and close content
 * We go down to a minimum of two cards, left aligned, for tablet only two should show with the third peeking 
 * Adds ability for more than 5 cards
 * Adds the ability to load styles-c2, allowing us to not pollute the global styles of bacom with revised typography

Resolves: [MWPW-202491](https://jira.corp.adobe.com/browse/MWPW-202491)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://main--da-bacom--adobecom.aem.live/drafts/slavin/iswa/iswa-v2/c2-blocks-parity?martech=off
- After: https://elastic-variants--da-bacom--adobecom.aem.live/drafts/slavin/iswa/iswa-v2/c2-blocks-parity?martech=off
