### PR TITLE
ISWA: Bento grid + video marquee fixes (MWPW-204890, MWPW-204832)

### DIFF
--- a/blocks/bento-grid/bento-grid.css
+++ b/blocks/bento-grid/bento-grid.css
@@ -2,6 +2,8 @@
 
 .bento-grid .foreground {
   width: 100%;
+  max-width: 1200px;
+  margin-inline: auto;
   position: relative;
 }
 
@@ -272,14 +274,9 @@
   letter-spacing: -0.72px;
 }
 
-/* stylelint-disable value-no-vendor-prefix */
 .bento-grid .grid-item-text .bento-description {
-  overflow: hidden;
   margin: 0;
   color: rgb(0 0 0 / 60%);
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
   font-family: "Adobe Clean", sans-serif;
   font-size: 16px;
   font-style: normal;
@@ -287,7 +284,6 @@
   line-height: 130%;
   letter-spacing: 0.16px;
 }
-/* stylelint-enable value-no-vendor-prefix */
 
 .bento-grid .grid-item-text .bento-watch-link {
   margin-top: 24px;
@@ -419,11 +415,11 @@
   }
 
   .bento-grid .bento-featured {
-    width: 1200px;
+    width: 100%;
     height: 599px;
-    margin: 0 auto;
     flex-direction: row;
     align-items: stretch;
+    padding-block: 24px;
   }
 
   .bento-grid .bento-featured-text,
@@ -432,21 +428,29 @@
     flex: 1 1 50%;
   }
 
+  .bento-grid .bento-featured-text .bento-description {
+    margin-bottom: 48px;
+  }
+
+  .bento-grid .bento-featured-text {
+    padding: 0 64px;
+  }
+
   .bento-grid .bento-featured-media {
     aspect-ratio: auto;
   }
 
   .bento-grid .grid-carousel {
-    width: auto;
-    margin-left: calc((100% - 1200px) / 2);
+    width: 100%;
+    margin-left: 0;
   }
 
   .bento-grid .grid-carousel-controls {
-    width: 1200px;
+    width: 100%;
   }
 
   .bento-grid .grid-item {
-    width: calc((1200px - (2 * 1rem)) / 3);
+    width: calc((100% - (2 * 1rem)) / 3);
   }
 
   .bento-grid .grid-item-media {

--- a/blocks/bento-grid/bento-grid.js
+++ b/blocks/bento-grid/bento-grid.js
@@ -132,19 +132,29 @@ function extractCells(container) {
     const sectionHeading = before.find(isHeading);
     const sectionSubtext = before.find((node) => node.tagName === 'P');
 
-    const heading = after.find(isHeading);
-    const paragraphs = after.filter((node) => node.tagName === 'P');
+    const headingIndex = after.findIndex(isHeading);
+    const heading = headingIndex === -1 ? undefined : after[headingIndex];
     const { videoSrc, fragmentPath, fragmentHash, node } = resolveCellVideo(after);
-    const ctaPara = node ? paragraphs.find((p) => p.contains(node)) : null;
-    const descPara = paragraphs.find((p) => p !== ctaPara
+    const ctaPara = node ? after.find((p) => p.tagName === 'P' && p.contains(node)) : null;
+    const isTextPara = (p) => p.tagName === 'P'
+      && p !== ctaPara
       && !p.querySelector('picture')
-      && p.textContent.trim());
+      && p.textContent.trim();
+
+    // Optional eyebrow: the first text paragraph authored before the heading.
+    const eyebrowPara = headingIndex > 0
+      ? after.slice(0, headingIndex).find(isTextPara)
+      : null;
+    // Description: the first text paragraph after the heading (any, if no heading).
+    const descScope = headingIndex === -1 ? after : after.slice(headingIndex + 1);
+    const descPara = descScope.find((p) => p !== eyebrowPara && isTextPara(p));
 
     return {
       pictureHTML: pic ? pic.outerHTML : '',
       videoSrc: videoSrc || null,
       fragmentPath,
       fragmentHash,
+      eyebrow: eyebrowPara?.textContent.trim() || '',
       heading: heading?.textContent.trim() || '',
       description: descPara?.textContent.trim() || '',
       sectionHeading: sectionHeading?.textContent.trim() || '',
@@ -309,7 +319,7 @@ function buildFeatured(cell) {
 
   const text = buildTextBlock({
     className: 'bento-featured-text',
-    eyebrow: 'Featured video',
+    eyebrow: cell.eyebrow,
     heading: cell.heading,
     description: cell.description,
     showWatchLink: true,

--- a/blocks/video-marquee/video-marquee.css
+++ b/blocks/video-marquee/video-marquee.css
@@ -4,7 +4,7 @@
   --marquee-headline-ls: -0.96px;
 
   background-color: #000;
-  padding-block: var(--spacing-xl);
+  padding-bottom: 56px;
   padding-inline: var(--grid-margin-width);
   margin: 0 auto;
 }

--- a/blocks/video-marquee/video-marquee.css
+++ b/blocks/video-marquee/video-marquee.css
@@ -6,7 +6,6 @@
   background-color: #000;
   padding-block: var(--spacing-xl);
   padding-inline: var(--grid-margin-width);
-  max-width: 1920px;
   margin: 0 auto;
 }
 
@@ -22,28 +21,29 @@
   flex-direction: column;
   justify-content: center;
   height: 100%;
+  max-width: 512px;
 }
 
 .video-marquee .marquee-eyebrow picture,
 .video-marquee .marquee-eyebrow img {
   display: block;
-  width: 80px;
-  height: 19px;
+  max-width: 168px;
+  height: 20px;
   margin-bottom: var(--spacing-xs);
 }
 
 .video-marquee .marquee-headline {
   margin: 0;
   color: var(--color-white);
-  font-family: adobe-clean-display, var(--font-family-adobe-clean-display, "Adobe Clean Display"), sans-serif;
-  font-size: var(--s2a-typography-font-size-title-1, var(--marquee-headline-size));
+  font-family: var(--heading-font-family);
+  font-size: 40px;
   font-weight: 900;
-  line-height: var(--s2a-typography-line-height-title-1, var(--marquee-headline-lh));
+  line-height: 40px;
   letter-spacing: var(--s2a-typography-letter-spacing-title-1, var(--marquee-headline-ls));
 }
 
 .video-marquee .marquee-subcopy {
-  margin: var(--spacing-xs) 0 0;
+  margin: 8px 0 0;
   max-width: 32em;
   color: #F8F8F8;
   font-family: var(--font-family-adobe-clean, "Adobe Clean"), adobe-clean, sans-serif;
@@ -53,8 +53,9 @@
   letter-spacing: var(--s2a-typography-letter-spacing-body-lg, 0);
 }
 
-.video-marquee .marquee-video-row {
-  min-width: 327px;
+/* Mobile video shows below 600px, desktop video at/above 600px (see media query). */
+.video-marquee .marquee-video-desktop {
+  display: none;
 }
 
 .video-marquee .marquee-media {
@@ -173,7 +174,18 @@
     --marquee-headline-lh: 48px;
     --marquee-headline-ls: -1.44px;
 
+    /* Center content within a 1200px max-width; keep the right edge flush so the
+       video can bleed out into the margin. */
+    padding-inline-start: max(var(--grid-margin-width), calc((100% - 1200px) / 2));
     padding-inline-end: 0;
+  }
+
+  .video-marquee .marquee-video-mobile {
+    display: none;
+  }
+
+  .video-marquee .marquee-video-desktop {
+    display: block;
   }
 
   .video-marquee .marquee-inner {
@@ -204,6 +216,23 @@
 
     padding-block: 80px;
   }
+
+  .video-marquee .marquee-eyebrow picture,
+  .video-marquee .marquee-eyebrow img {
+    height: 30px;
+    width: 100%;
+    max-width: 300px;
+  }
+
+  .video-marquee .marquee-headline { 
+    font-size: 72px;
+    letter-spacing: -2.88px;
+    line-height: 100%;
+  }
+
+  .video-marquee .marquee-subcopy {
+    padding-right: 40px;
+  }
 }
 
 @media (min-width: 769px) and (max-width: 1279px) {
@@ -220,7 +249,9 @@
 
 @media (min-width: 1280px) {
   .video-marquee .marquee-inner {
-    grid-template-columns: 557fr 768fr;
+    /* Text capped to its share of the 1200px content box; video = 1fr fills the
+       rest and bleeds out to the right edge. */
+    grid-template-columns: minmax(0, 557px) 1fr;
     gap: 35px;
   }
 }

--- a/blocks/video-marquee/video-marquee.js
+++ b/blocks/video-marquee/video-marquee.js
@@ -207,16 +207,80 @@ function watchReducedMotion(video) {
   });
 }
 
+const ATV_RE = /tv\.adobe\.com\/v\//i;
+const MP4_RE = /\.mp4(\?|#|$)/i;
+
+// A video cell can be authored as an inline video ("video in doc") or a link,
+// and either an mp4 (native <video>) or a video.tv.adobe.com link (MPC iframe).
+// Resolve the cell to one of: an already-decorated MPC embed, a tv.adobe.com
+// link, or an mp4 source (from an existing <video>, an mp4 link, or a poster
+// <picture> whose img alt encodes the mp4 as `url#flags | label`).
+function resolveSource(cell) {
+  if (!cell) return null;
+
+  const embed = cell.querySelector('.milo-video, iframe.adobetv, iframe[src*="tv.adobe.com" i]');
+  if (embed) return { type: 'embed' };
+
+  const atvLink = [...cell.querySelectorAll('a')]
+    .find((a) => ATV_RE.test(a.getAttribute('href') || ''));
+  if (atvLink) return { type: 'atv', url: atvLink.getAttribute('href') };
+
+  const existingVideo = cell.querySelector('video');
+  if (existingVideo) {
+    const src = existingVideo.querySelector('source')?.src
+      || existingVideo.currentSrc
+      || existingVideo.getAttribute('data-video-source');
+    if (src) return { type: 'mp4', src, hash: '' };
+  }
+
+  const mp4Link = [...cell.querySelectorAll('a')]
+    .find((a) => MP4_RE.test(a.getAttribute('href') || ''));
+  if (mp4Link) return { type: 'mp4', src: mp4Link.href, hash: (mp4Link.hash || '').toLowerCase() };
+
+  const posterImg = [...cell.querySelectorAll('picture img')]
+    .find((img) => MP4_RE.test(img.getAttribute('alt') || ''));
+  if (posterImg) {
+    const [urlPart] = (posterImg.getAttribute('alt') || '').split('|');
+    const [src, hashPart] = urlPart.trim().split('#');
+    return {
+      type: 'mp4',
+      src,
+      hash: hashPart ? `#${hashPart}`.toLowerCase() : '',
+      poster: posterImg.currentSrc || posterImg.getAttribute('src') || '',
+    };
+  }
+
+  return null;
+}
+
+function buildAtvIframe(url) {
+  const iframe = document.createElement('iframe');
+  iframe.src = url;
+  iframe.className = 'marquee-atv';
+  iframe.title = 'Adobe Video Publishing Cloud Player';
+  iframe.setAttribute('scrolling', 'no');
+  iframe.setAttribute('allow', 'encrypted-media; fullscreen');
+  iframe.setAttribute('loading', 'lazy');
+  return iframe;
+}
+
 function decorateVideo(cell, labels, locale) {
   if (!cell) return;
 
-  const existingVideo = cell.querySelector('video');
-  const link = cell.querySelector('a[href*=".mp4" i]');
-  const captionsLink = cell.querySelector('a[href*=".vtt" i]');
-  const src = existingVideo?.querySelector('source')?.src || existingVideo?.currentSrc || link?.href;
-  if (!src) return;
+  const info = resolveSource(cell);
+  if (!info) return;
 
-  const hash = (link?.hash || '').toLowerCase();
+  cell.classList.add('marquee-media');
+
+  if (info.type === 'embed') return;
+
+  if (info.type === 'atv') {
+    cell.replaceChildren(buildAtvIframe(info.url));
+    return;
+  }
+
+  const captionsLink = cell.querySelector('a[href*=".vtt" i]');
+  const hash = info.hash || '';
   const hoverPlay = hash.includes('hoverplay');
   const viewportPlay = hash.includes('viewportplay');
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -225,10 +289,11 @@ function decorateVideo(cell, labels, locale) {
   video.muted = true;
   video.loop = true;
   video.playsInline = true;
+  if (info.poster) video.poster = info.poster;
   if (!prefersReducedMotion && !hoverPlay && !viewportPlay) video.autoplay = true;
 
   const source = document.createElement('source');
-  source.src = src;
+  source.src = info.src;
   source.type = 'video/mp4';
   video.append(source);
 
@@ -245,7 +310,6 @@ function decorateVideo(cell, labels, locale) {
     controls.append(buildCaptionsToggle(track.track, labels));
   }
 
-  cell.classList.add('marquee-media');
   cell.replaceChildren(video, controls);
 
   watchReducedMotion(video);
@@ -262,14 +326,22 @@ export default async function init(el) {
   el.classList.add('dark');
 
   const rows = [...el.querySelectorAll(':scope > div')];
-  const [logoRow, contentRow, videoRow] = rows.length >= 3 ? rows : [undefined, ...rows];
-  if (!contentRow) return;
+  const cellOf = (row) => row.querySelector(':scope > div') || row;
 
-  const contentCell = contentRow.querySelector(':scope > div') || contentRow;
+  // Classify rows by content, so a logo is optional and one or two video rows
+  // are both supported (first video = mobile, second = desktop).
+  const videoRows = rows.filter((row) => resolveSource(cellOf(row)));
+  const nonVideoRows = rows.filter((row) => !videoRows.includes(row));
+  const contentRow = nonVideoRows.find((row) => row.querySelector('h1, h2, h3, h4, h5, h6'))
+    || nonVideoRows.find((row) => [...row.querySelectorAll('p')].some((p) => p.textContent.trim()));
+  if (!contentRow) return;
+  const logoRow = nonVideoRows.find((row) => row !== contentRow && row.querySelector('picture'));
+
+  const contentCell = cellOf(contentRow);
   contentCell.classList.add('marquee-content');
   contentRow.classList.add('marquee-content-row');
 
-  const logoCell = logoRow?.querySelector(':scope > div') || logoRow;
+  const logoCell = logoRow ? cellOf(logoRow) : null;
   const logo = logoCell?.querySelector('picture');
   if (logo) {
     const eyebrow = document.createElement('div');
@@ -286,15 +358,20 @@ export default async function init(el) {
     if (p.textContent?.trim()) p.classList.add('marquee-subcopy');
   });
 
-  if (videoRow) {
-    videoRow.classList.add('marquee-video-row');
+  if (videoRows.length) {
     const [labels, locale] = await Promise.all([loadLabels(), getLocaleInfo()]);
-    decorateVideo(videoRow.querySelector(':scope > div') || videoRow, labels, locale);
+    videoRows.forEach((videoRow, i) => {
+      videoRow.classList.add('marquee-video-row');
+      if (videoRows.length > 1) {
+        videoRow.classList.add(i === 0 ? 'marquee-video-mobile' : 'marquee-video-desktop');
+      }
+      decorateVideo(cellOf(videoRow), labels, locale);
+    });
   }
 
   const inner = document.createElement('div');
   inner.className = 'marquee-inner';
   inner.append(contentRow);
-  if (videoRow) inner.append(videoRow);
+  videoRows.forEach((videoRow) => inner.append(videoRow));
   el.append(inner);
 }

--- a/test/blocks/bento-grid/bento-grid.test.js
+++ b/test/blocks/bento-grid/bento-grid.test.js
@@ -42,6 +42,12 @@ describe('Bento Grid', () => {
       expect(featured.querySelector('.grid-item-play')).to.exist;
     });
 
+    it('does not render an eyebrow when none is authored', () => {
+      const desktopView = document.querySelector('.grid-view.view-desktop');
+      const featured = desktopView.querySelector('.bento-featured');
+      expect(featured.querySelector('.bento-eyebrow')).to.not.exist;
+    });
+
     it('resolves the featured card video source from the mp4 link and makes it a link', () => {
       const desktopView = document.querySelector('.grid-view.view-desktop');
       const featured = desktopView.querySelector('.bento-featured');
@@ -78,6 +84,26 @@ describe('Bento Grid', () => {
       const cards = mobileView.querySelectorAll('.grid-carousel .grid-item');
       // all 6 cells (2 in row 1 + 4 in row 2) become carousel cards on mobile
       expect(cards.length).to.equal(6);
+    });
+  });
+
+  describe('authored eyebrow', () => {
+    before(async () => {
+      document.body.innerHTML = await readFile({ path: './mocks/eyebrow.html' });
+      await init(document.querySelector('.bento-grid'));
+    });
+
+    it('renders the authored eyebrow on the featured card', () => {
+      const featured = document.querySelector('.grid-view.view-desktop .bento-featured');
+      const eyebrow = featured.querySelector('.bento-eyebrow');
+      expect(eyebrow).to.exist;
+      expect(eyebrow.textContent).to.equal('Watch the keynote');
+    });
+
+    it('does not treat the authored eyebrow as the description', () => {
+      const featured = document.querySelector('.grid-view.view-desktop .bento-featured');
+      expect(featured.querySelector('.bento-heading').textContent).to.equal('Featured heading');
+      expect(featured.querySelector('.bento-description').textContent).to.equal('Featured description text.');
     });
   });
 

--- a/test/blocks/bento-grid/mocks/eyebrow.html
+++ b/test/blocks/bento-grid/mocks/eyebrow.html
@@ -1,0 +1,27 @@
+<div class="bento-grid">
+  <div>
+    <div>
+      <p>viewport=desktop</p>
+      <p>r-1--start-index=1</p>
+      <p>r-1--left=0</p>
+      <p>r-2--start-index=1</p>
+      <p>r-2--left=0</p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <p><picture><img src="./media_1.png" alt=""></picture></p>
+      <p>Watch the keynote</p>
+      <h3>Featured heading</h3>
+      <p>Featured description text.</p>
+      <p><a href="https://example.com/video1.mp4">https://example.com/video1.mp4</a></p>
+    </div>
+  </div>
+  <div>
+    <div>
+      <p><picture><img src="./media_3.png" alt=""></picture></p>
+      <h3>Card three heading</h3>
+      <p>Card three description.</p>
+    </div>
+  </div>
+</div>

--- a/test/blocks/video-marquee/video-marquee.test.js
+++ b/test/blocks/video-marquee/video-marquee.test.js
@@ -168,4 +168,47 @@ describe('Video Marquee', () => {
     const video = document.querySelector('.marquee-media video');
     expect(video.autoplay).to.be.false;
   });
+
+  it('splits two video rows into mobile and desktop, constructing each source', async () => {
+    document.body.innerHTML = `<div class="video-marquee">
+      <div><div><picture><img alt="" src="/logo.svg"></picture></div></div>
+      <div><div><h1>From idea to impact.</h1><p>Subcopy.</p></div></div>
+      <div><div><a href="https://video.tv.adobe.com/v/3497295">https://video.tv.adobe.com/v/3497295</a></div></div>
+      <div><div><picture><img alt="https://example.com/media_x.mp4#_autoplay1 | Play overview video" src="/poster.png"></picture></div></div>
+    </div>`;
+
+    await init(document.querySelector('.video-marquee'));
+
+    const mobile = document.querySelector('.marquee-video-mobile');
+    const desktop = document.querySelector('.marquee-video-desktop');
+    expect(mobile).to.exist;
+    expect(desktop).to.exist;
+
+    // mobile tv.adobe.com link -> MPC iframe (no native video)
+    const iframe = mobile.querySelector('iframe.marquee-atv');
+    expect(iframe).to.exist;
+    expect(iframe.getAttribute('src')).to.equal('https://video.tv.adobe.com/v/3497295');
+    expect(mobile.querySelector('video')).to.not.exist;
+
+    // desktop mp4-in-alt poster -> native video with source + poster
+    const video = desktop.querySelector('video');
+    expect(video).to.exist;
+    expect(video.querySelector('source').getAttribute('src')).to.equal('https://example.com/media_x.mp4');
+    expect(video.getAttribute('poster')).to.contain('poster.png');
+  });
+
+  it('does not add mobile/desktop classes for a single video (back-compat)', async () => {
+    document.body.innerHTML = `<div class="video-marquee">
+      <div><div><h1>Heading</h1></div></div>
+      <div><div>
+        <p><a href="https://example.com/video.mp4">Video</a></p>
+      </div></div>
+    </div>`;
+
+    await init(document.querySelector('.video-marquee'));
+
+    expect(document.querySelector('.marquee-media video')).to.exist;
+    expect(document.querySelector('.marquee-video-mobile')).to.not.exist;
+    expect(document.querySelector('.marquee-video-desktop')).to.not.exist;
+  });
 });


### PR DESCRIPTION
**Bento grid — Leadership POV Bento Box**
* Made the "Featured video" eyebrow authorable — renders when present, cleanly omitted when absent (previously hardcoded)
* Tightened the featured card's left/right padding to match Figma (88px / 72px)
* Removed the 3-line ellipsis clamp on non-featured cards so the full description shows
* Moved the block to a fluid, centered 1200px max-width so cards fill and side margins stay even on wide screens

**Video marquee — mobile video + tv.adobe.com**
* Support separate mobile and desktop videos (first video shows below 600px, second at/above 600px); single-video authoring still works
* Each video cell can be authored as an inline video or a link, and as an mp4 (native `<video>` with custom controls) or a `video.tv.adobe.com` link (MPC iframe embed)
* Mobile spacing and typography refinements
* Capped content to a centered 1200px width while letting the video bleed off the right edge into the margin

Resolves: [MWPW-204890](https://jira.corp.adobe.com/browse/MWPW-204890)
Resolves: [MWPW-204832](https://jira.corp.adobe.com/browse/MWPW-204832)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.page/resources/iswa-v2/it-starts-with-adobe?martech=off
- After: https://iswa-fixes--da-bacom--adobecom.aem.page/resources/iswa-v2/it-starts-with-adobe?martech=off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
