### PR TITLE
ISWA: 1200px grid alignment & typography fixes across blocks (MWPW-204509)

### DIFF
--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
@@ -79,18 +79,12 @@ html[dir="rtl"] {
         }
 
         p {
-          font-size: var(--s2a-font-size-sm);
-          font-weight: var(--s2a-font-weight-adobe-clean-bold);
+          font-size: 18px;
+          font-weight: 800;
           color: var(--s2a-color-gray-1000);
           margin: 0;
           transition: color .1s ease;
-          line-height: var(--s2a-font-line-height-18);
-          display: -webkit-box;
-          line-clamp: 1;
-          box-orient: vertical;
-          -webkit-box-orient: vertical;
-          -webkit-line-clamp: 1;
-          overflow: hidden;
+          line-height: 22px;
         }
       }
 
@@ -620,8 +614,8 @@ html[dir="rtl"] {
 
     p {
       margin: 0;
-      padding: var(--s2a-spacing-md) var(--s2a-spacing-lg);
-      font-size: var(--s2a-font-size-sm);
+      padding: 0 24px 24px;
+      font-size: 16px;
       line-height: var(--s2a-font-line-height-18);
       color: var(--elastic-expand-panel-color);
       text-align: left;

--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
@@ -530,7 +530,6 @@ html[dir="rtl"] {
   --elastic-media-height: 316px;
 
   .elastic-carousel-container {
-    max-width: 90%;
     justify-self: center;
   }
 
@@ -705,6 +704,8 @@ html[dir="rtl"] .elastic-carousel-footer-chevron {
 
 @media (width < 768px) {
   .bacom-elastic-carousel:is(.expand-content, .limited) {
+    margin-inline: 0;
+
     .elastic-carousel-container .elastic-carousel-item {
       color: var(--s2a-color-gray-1000);
 
@@ -736,8 +737,11 @@ html[dir="rtl"] .elastic-carousel-footer-chevron {
 .bacom-elastic-carousel.limited {
   --limited-visible-slides: 3;
   --limited-card-max-width: 394px;
-  --limited-group-max-width: calc((var(--limited-card-max-width) * var(--limited-visible-slides)) + (var(--s2a-spacing-md) * (var(--limited-visible-slides) - 1)));
-  --limited-bleed-space: max(0px, calc(100vw - var(--grid-margin-width) - var(--limited-group-max-width)));
+  --limited-gap: var(--s2a-spacing-8);
+  --limited-content-max-width: 1200px;
+  --limited-group-max-width: calc((var(--limited-card-max-width) * var(--limited-visible-slides)) + (var(--limited-gap) * (var(--limited-visible-slides) - 1)));
+  --limited-inset: max(var(--grid-margin-width), calc((100vw - var(--limited-content-max-width)) / 2));
+  --limited-bleed-space: max(0px, calc(100vw - var(--limited-inset) - var(--limited-group-max-width)));
 
   .elastic-carousel-limited-controls {
     display: none;
@@ -751,7 +755,7 @@ html[dir="rtl"] .elastic-carousel-footer-chevron {
 @media (width >= 768px) {
   .bacom-elastic-carousel.limited {
     height: auto;
-    padding-inline-start: var(--grid-margin-width);
+    padding-inline-start: var(--limited-inset);
     overflow: visible;
 
     .elastic-carousel-viewport {
@@ -765,7 +769,7 @@ html[dir="rtl"] .elastic-carousel-footer-chevron {
       display: flex;
       max-width: none;
       justify-self: auto;
-      column-gap: var(--s2a-spacing-md);
+      column-gap: var(--limited-gap);
       overflow-x: auto;
       overflow-y: visible;
       scroll-snap-type: x mandatory;

--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
@@ -72,6 +72,7 @@ html[dir="rtl"] {
         padding: var(--s2a-spacing-lg);
         gap: var(--s2a-spacing-md);
         align-items: center;
+        min-height: 48px;
 
         img {
           width: 24px;

--- a/blocks/bacom-news/bacom-news.css
+++ b/blocks/bacom-news/bacom-news.css
@@ -53,6 +53,7 @@
         text-overflow: ellipsis;
         margin-bottom: var(--s2a-spacing-lg);
         color: var(--s2a-color-content-body-subtle);
+        letter-spacing: 0.16px;
       }
 
       .news-item-link {

--- a/blocks/bacom-news/bacom-news.css
+++ b/blocks/bacom-news/bacom-news.css
@@ -154,7 +154,7 @@ html[dir="rtl"] .bacom-news .news-carousel-arrow-next .news-carousel-arrow-icon 
   .bacom-news {
     display: flex;
     flex-direction: column;
-    gap: var(--s2a-spacing-2xl);
+    gap: 24px;
     padding-inline: var(--s2a-spacing-16);
 
     .news-headline {
@@ -176,6 +176,7 @@ html[dir="rtl"] .bacom-news .news-carousel-arrow-next .news-carousel-arrow-icon 
 
     .news-carousel-controls {
       padding: var(--s2a-spacing-0);
+      margin-bottom: 32px;
     }
   }
 }

--- a/blocks/bacom-news/bacom-news.css
+++ b/blocks/bacom-news/bacom-news.css
@@ -137,6 +137,17 @@ html[dir="rtl"] .bacom-news .news-carousel-arrow-next .news-carousel-arrow-icon 
   }
 }
 
+/* classic 1200px grid alignment (desktop) */
+@media (width >= 768px) {
+  .section.container:has(> .bacom-news) {
+    --grid-content-width: 1200px;
+  }
+
+  .section.container > .bacom-news {
+    margin-inline: calc(-1 * var(--s2a-spacing-lg));
+  }
+}
+
 @media screen and (width < 768px) {
   .bacom-news {
     display: flex;

--- a/blocks/bacom-news/bacom-news.css
+++ b/blocks/bacom-news/bacom-news.css
@@ -54,6 +54,7 @@
         margin-bottom: var(--s2a-spacing-lg);
         color: var(--s2a-color-content-body-subtle);
         letter-spacing: 0.16px;
+        min-height: 48px;
       }
 
       .news-item-link {

--- a/blocks/bacom-rich-content/bacom-rich-content.css
+++ b/blocks/bacom-rich-content/bacom-rich-content.css
@@ -202,6 +202,15 @@
   }
 }
 
+/* classic 1200px grid alignment (desktop opt-in) */
+@media (width >= 768px) {
+  .bacom-rich-content.classic-grid-spacing {
+    --grid-content-width: 1200px;
+
+    padding-inline: max(var(--grid-margin-width), calc((100% - var(--grid-content-width)) / 2));
+  }
+}
+
 .section {
   &:has(.bacom-rich-content.hero) {
     box-sizing: border-box;

--- a/blocks/bacom-rich-content/bacom-rich-content.css
+++ b/blocks/bacom-rich-content/bacom-rich-content.css
@@ -302,6 +302,10 @@
     min-width: initial;
   }
 
+  .bacom-rich-content.narrow.classic-grid-spacing .content [class*="body-"]:not(.action-area) {
+    max-width: 630px;
+  }
+
   .section:has(.bacom-rich-content.jump-link.hero) {
     height: auto;
   }

--- a/blocks/bacom-rich-content/bacom-rich-content.css
+++ b/blocks/bacom-rich-content/bacom-rich-content.css
@@ -273,17 +273,22 @@
     --rc-sweep-offset: 230px;
   }
 
+  .bacom-rich-content .foreground .content p {
+    font-size: 18px;
+  }
+
   .bacom-rich-content.narrow .content [class*="heading-"]:not(.action-area) {
-    max-width: 680px;
+    max-width: 1200px;
   }
 
   .bacom-rich-content.narrow-xs .content [class*="heading-"]:not(.action-area) {
     max-width: 560px;
   }
 
-  .bacom-rich-content .content [class*="body-"]:not(.action-area) {
+  .bacom-rich-content .foreground .content [class*="body-"]:not(.action-area) {
     min-width: 560px;
     width: calc((100% / var(--grid-columns)) * 8);
+    max-width: 1200px;
 
     .section[class*='-up'] & {
       min-width: unset;

--- a/blocks/bento-grid/bento-grid.css
+++ b/blocks/bento-grid/bento-grid.css
@@ -283,6 +283,7 @@
   font-weight: 400;
   line-height: 130%;
   letter-spacing: 0.16px;
+  min-height: 100px;
 }
 
 .bento-grid .grid-item-text .bento-watch-link {

--- a/blocks/bento-grid/bento-grid.css
+++ b/blocks/bento-grid/bento-grid.css
@@ -28,7 +28,7 @@
   margin: 0 0 8px;
   color: var(--s2a-color-content-title);
   text-align: left;
-  font-family: "Adobe Clean", sans-serif;
+  font-family: var(--body-font-family);
   font-size: 32px;
   font-style: normal;
   font-weight: 900;
@@ -40,7 +40,7 @@
   margin: 0;
   color: var(--s2a-color-content-body-strong);
   text-align: left;
-  font-family: "Adobe Clean", sans-serif;
+  font-family: var(--body-font-family);
   font-size: var(--s2a-typography-font-size-body-lg);
   font-style: normal;
   font-weight: 400;
@@ -125,7 +125,7 @@
 .bento-grid .bento-featured-text .bento-description {
   color: rgb(0 0 0 / 60%);
   white-space: normal;
-  font-family: "Adobe Clean", sans-serif;
+  font-family: var(--body-font-family);
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
@@ -139,7 +139,7 @@
   gap: 0.375rem;
   color: #000;
   text-align: center;
-  font-family: "Adobe Clean", sans-serif;
+  font-family: var(--body-font-family);
   font-size: 14px;
   font-style: normal;
   font-weight: 700;
@@ -277,7 +277,7 @@
 .bento-grid .grid-item-text .bento-description {
   margin: 0;
   color: rgb(0 0 0 / 60%);
-  font-family: "Adobe Clean", sans-serif;
+  font-family: var(--body-font-family);
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
@@ -363,7 +363,7 @@
   .bento-grid .bento-section-heading {
     text-align: center;
     color: #000;
-    font-family: "Adobe Clean Display", sans-serif;
+    font-family: var(--body-font-family);
     font-size: 56px;
     line-height: 100%;
     letter-spacing: -1.68px;
@@ -374,7 +374,7 @@
     max-width: 600px;
     text-align: center;
     color: #000;
-    font-family: "Adobe Clean", sans-serif;
+    font-family: var(--body-font-family);
     font-size: 18px;
     line-height: 130%;
     letter-spacing: 0.18px;

--- a/blocks/resource-showcase/resource-showcase.css
+++ b/blocks/resource-showcase/resource-showcase.css
@@ -4,15 +4,12 @@
 
   position: relative;
   padding: var(--spacing-xl) var(--spacing-xs);
-  background-image:
-    radial-gradient(circle at 0% 0%, rgb(216 130 80 / 45%), transparent 45%),
-    linear-gradient(135deg, #6b5a4e 0%, #4a4846 30%, #33343a 60%, #1c1d22 100%);
   overflow: hidden;
 }
 
 .resource-showcase .resource-showcase-heading {
-  max-width: var(--resource-showcase-max-width);
-  margin: 0 auto var(--spacing-m);
+  max-width: 327px;
+  margin: 0 auto 40px;
   color: var(--color-white);
   font-size: 32px;
   line-height: 32px;
@@ -25,7 +22,7 @@
   max-width: var(--resource-showcase-max-width);
   margin: 0 auto;
   grid-template-columns: 1fr;
-  gap: var(--spacing-l);
+  gap: 56px;
 }
 
 /* CTA link, shared by featured card and secondary items */
@@ -135,7 +132,7 @@
 .resource-showcase .resource-showcase-list {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-m);
+  gap: 48px;
   margin: 0;
   padding: 0;
   min-width: 0;
@@ -177,6 +174,8 @@
   }
 
   .resource-showcase .resource-showcase-heading {
+    max-width: var(--resource-showcase-max-width);
+    margin: 0 auto 56px;
     font-size: 48px;
     line-height: 48px;
     letter-spacing: -1.44px;

--- a/blocks/video-marquee/video-marquee.css
+++ b/blocks/video-marquee/video-marquee.css
@@ -220,7 +220,6 @@
   .video-marquee .marquee-eyebrow picture,
   .video-marquee .marquee-eyebrow img {
     height: 30px;
-    width: 100%;
     max-width: 300px;
   }
 


### PR DESCRIPTION
Grid alignment and typography fixes across several C2 blocks (ISWA small-fixes follow-up):

**bacom-elastic-carousel**
* Contain the `limited` carousel to a centered 1200px band on desktop (replaces the left grid-margin inline padding); gutters grow symmetrically above ~1440px. Card gap tightened 16px → 8px so three cards fit the band; the >3-card carousel and right-side bleed are preserved.
* Mobile cards now span the full viewport width edge-to-edge for the expand-content/limited variants.
* Typography: card title 18px/800 with 22px line-height and a 48px header min-height (title clamp removed); expand-panel copy 16px with revised padding. Removed the leftover `max-width: 90%` on the expand-content container.

**bacom-rich-content**
* New opt-in `classic-grid-spacing` desktop class that aligns the block to the centered 1200px grid band.
* Desktop body copy set to 18px; narrow heading/body max-widths adjusted (up to 1200px), plus a 630px body cap when `narrow` + `classic-grid-spacing` are combined.

**bacom-news**
* Desktop 1200px grid alignment (no new class) — the containing section's content width is capped to 1200px and the block content is flushed to the band, preserving the existing inter-column gutters. Works for both the 3-up grid and the >3 carousel.
* Body copy: 0.16px letter-spacing and a 48px min-height for even card heights.

**bento-grid**
* Standardized headings/descriptions to `var(--body-font-family)`; grid-item description min-height 100px for consistent rows.

**resource-showcase**
* Removed the block's built-in dark gradient background; refined heading sizing/margins (mobile & desktop) and increased content/list spacing (56px / 48px).

**video-marquee**
* Fixed eyebrow icon warping (dropped `width: 100%`, keeping `max-width: 300px`).

Resolves: [MWPW-204509](https://jira.corp.adobe.com/browse/MWPW-204509)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.page/resources/iswa-v2/it-starts-with-adobe?martech=off
- After: https://iswa-fixes--da-bacom--adobecom.aem.page/resources/iswa-v2/it-starts-with-adobe?martech=off
