### PR TITLE
ISWA: Small fixes — news carousel, footer, personalization & video-marquee security (MWPW-204509, MWPW-205051)

### DIFF
--- a/blocks/bacom-news/bacom-news.js
+++ b/blocks/bacom-news/bacom-news.js
@@ -31,8 +31,9 @@ function isLastCardVisible(container) {
   const cards = container.querySelectorAll('.news-item');
   const lastCard = cards[cards.length - 1];
   if (!lastCard) return true;
-  const cardRect = lastCard.getBoundingClientRect();
   const frameRect = container.getBoundingClientRect();
+  if (frameRect.width === 0) return false;
+  const cardRect = lastCard.getBoundingClientRect();
   return cardRect.left >= frameRect.left - 1 && cardRect.right <= frameRect.right + 1;
 }
 
@@ -53,8 +54,7 @@ function buildCarouselControls(container) {
 
   const refresh = () => updateArrowState(container, prevBtn, nextBtn);
   container.addEventListener('scroll', refresh);
-  window.addEventListener('resize', refresh);
-  requestAnimationFrame(refresh);
+  new ResizeObserver(refresh).observe(container);
 
   return controls;
 }

--- a/blocks/video-marquee/video-marquee.js
+++ b/blocks/video-marquee/video-marquee.js
@@ -1,7 +1,8 @@
 import { LIBS, PLAY_SVG } from '../../scripts/scripts.js';
 
-const ICON_BASE = '/blocks/video-marquee/icons';
-const iconCache = new Map();
+const PAUSE_SVG = '<svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><rect x="6" y="4" width="4" height="16" fill="currentColor"/><rect x="14" y="4" width="4" height="16" fill="currentColor"/></svg>';
+const MUTE_SVG = '<svg viewBox="0 0 32 32" width="20" height="20" aria-hidden="true" focusable="false"><path d="M30.0481 28.3828L3.64806 1.98279C3.17931 1.51404 2.41993 1.51404 1.95118 1.98279C1.48243 2.45154 1.48243 3.21092 1.95118 3.67967L6.30587 8.03436H5.19961C3.21524 8.03436 1.59961 9.64999 1.59961 11.6344V20.4344C1.59961 22.4187 3.21524 24.0344 5.19961 24.0344H7.80587C8.12305 24.0344 8.43243 24.1625 8.6543 24.3844L12.8199 28.5515C13.3574 29.089 14.0699 29.3734 14.7965 29.3734C15.1574 29.3734 15.5215 29.3031 15.8699 29.1578C16.9215 28.7234 17.5996 27.7078 17.5996 26.5703V19.3281L28.3512 30.0797C28.5855 30.314 28.8918 30.4312 29.1996 30.4312C29.5074 30.4312 29.8137 30.314 30.048 30.0797C30.5168 29.6109 30.5168 28.8515 30.0481 28.3828ZM15.1996 26.5703C15.1996 26.8031 15.0449 26.9031 14.9527 26.9406C14.859 26.9797 14.6793 27.0156 14.5168 26.8547L10.3512 22.6875C9.6715 22.0078 8.76836 21.6344 7.80587 21.6344H5.19961C4.53867 21.6344 3.99961 21.0953 3.99961 20.4344V11.6344C3.99961 10.9734 4.53867 10.4344 5.19961 10.4344H8.70587L15.1996 16.9281L15.1996 26.5703Z" fill="currentColor"/><path d="M13.2145 6.51724L14.5176 5.21412C14.6848 5.05005 14.8629 5.09224 14.9535 5.12661C15.066 5.17349 15.2004 5.27504 15.2004 5.49693V9.64224C15.2004 10.3047 15.7379 10.8422 16.4004 10.8422C17.0629 10.8422 17.6004 10.3047 17.6004 9.64224V5.49693C17.6004 4.361 16.9223 3.34536 15.8723 2.90943C14.8207 2.47661 13.6254 2.71412 12.8207 3.51724L11.5176 4.82036C11.0488 5.28911 11.0488 6.04848 11.5176 6.51724C11.9863 6.98599 12.7457 6.98599 13.2145 6.51724Z" fill="currentColor"/><path d="M21.1558 15.7203C21.2199 16.3375 21.7402 16.7969 22.348 16.7969C22.3886 16.7969 22.4308 16.7953 22.473 16.7906C23.1324 16.7219 23.612 16.1328 23.5433 15.4734C23.3839 13.9328 22.6261 12.6031 21.4652 11.8297C20.9136 11.4641 20.1683 11.6125 19.8011 12.1625C19.4339 12.7141 19.5824 13.4594 20.1339 13.8266C20.6902 14.1969 21.0714 14.9047 21.1558 15.7203Z" fill="currentColor"/><path d="M27.6008 16.0282C27.6008 17.4141 27.1461 18.7266 26.3196 19.7235C25.8977 20.2344 25.9696 20.9907 26.4789 21.4141C26.7039 21.5985 26.9743 21.6891 27.2446 21.6891C27.5883 21.6891 27.9321 21.5407 28.1696 21.2547C29.3508 19.8266 30.0008 17.9704 30.0008 16.0282C30.0008 13.3313 28.7243 10.8032 26.668 9.42974C26.1117 9.06256 25.3696 9.21099 25.0024 9.76099C24.6352 10.3126 24.7836 11.0579 25.3336 11.4266C26.7321 12.3594 27.6008 14.1235 27.6008 16.0282Z" fill="currentColor"/></svg>';
+const UNMUTE_SVG = '<svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false"><path d="M4 9V15H8L13 20V4L8 9H4Z" fill="currentColor"/><path d="M16.5 12C16.5 10.23 15.73 8.71 14.5 7.68V16.32C15.73 15.29 16.5 13.77 16.5 12Z" fill="currentColor"/><path d="M18.5 5.36L17.23 6.63C19.07 8.1 20 9.95 20 12C20 14.05 19.07 15.9 17.23 17.37L18.5 18.64C20.72 16.9 22 14.6 22 12C22 9.4 20.72 7.1 18.5 5.36Z" fill="currentColor"/></svg>';
 
 const DEFAULT_LABELS = {
   playVideo: 'Play video',
@@ -45,15 +46,6 @@ async function getLocaleInfo() {
   } catch {
     return fallback;
   }
-}
-
-function loadIcon(name) {
-  if (!iconCache.has(name)) {
-    iconCache.set(name, fetch(`${ICON_BASE}/${name}.svg`)
-      .then((resp) => (resp.ok ? resp.text() : ''))
-      .catch(() => ''));
-  }
-  return iconCache.get(name);
 }
 
 function buildScrubber(video, labels) {
@@ -104,17 +96,13 @@ function buildControls(video, labels, onUserToggle) {
     const isPaused = video.paused || video.ended;
     playPauseBtn.setAttribute('aria-label', isPaused ? labels.playVideo : labels.pauseVideo);
     playPauseBtn.setAttribute('aria-pressed', String(!isPaused));
-    if (isPaused) {
-      playPauseBtn.innerHTML = PLAY_SVG;
-    } else {
-      loadIcon('pause').then((svg) => { playPauseBtn.innerHTML = svg; });
-    }
+    playPauseBtn.innerHTML = isPaused ? PLAY_SVG : PAUSE_SVG;
   };
 
   const updateMute = () => {
     muteBtn.setAttribute('aria-label', video.muted ? labels.unmuteVideo : labels.muteVideo);
     muteBtn.setAttribute('aria-pressed', String(video.muted));
-    loadIcon(video.muted ? 'mute' : 'unmute').then((svg) => { muteBtn.innerHTML = svg; });
+    muteBtn.innerHTML = video.muted ? MUTE_SVG : UNMUTE_SVG;
   };
 
   playPauseBtn.addEventListener('click', () => {
@@ -210,11 +198,6 @@ function watchReducedMotion(video) {
 const ATV_RE = /tv\.adobe\.com\/v\//i;
 const MP4_RE = /\.mp4(\?|#|$)/i;
 
-// A video cell can be authored as an inline video ("video in doc") or a link,
-// and either an mp4 (native <video>) or a video.tv.adobe.com link (MPC iframe).
-// Resolve the cell to one of: an already-decorated MPC embed, a tv.adobe.com
-// link, or an mp4 source (from an existing <video>, an mp4 link, or a poster
-// <picture> whose img alt encodes the mp4 as `url#flags | label`).
 function resolveSource(cell) {
   if (!cell) return null;
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -363,6 +363,25 @@ export async function loadPage() {
     });
   }
 
+  // Target's init() reassigns config.mep and drops our block overrides. Re-inject on set.
+  const targetOn = getMetadata('target') || new URLSearchParams(window.location.search).get('target');
+  if (targetOn && getMetadata('foundation') === 'c2') {
+    const config = getConfig();
+    const desiredBlocks = {
+      'global-navigation': `${LIBS}/blocks/global-navigation`,
+      'global-footer': `${LIBS}/blocks/global-footer`,
+    };
+    let mepInternal = config.mep;
+    Object.defineProperty(config, 'mep', {
+      configurable: true,
+      get() { return mepInternal; },
+      set(v) {
+        if (v && typeof v === 'object') v.blocks = { ...v.blocks, ...desiredBlocks };
+        mepInternal = v;
+      },
+    });
+  }
+
   await loadArea();
 
   if (getMetadata('iswa-typography') === 'on') applyIswaTypography();

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -273,6 +273,10 @@ body.disable-scroll #adbMsgClientWrapper #adbmsgContainer .adbmsgCta {
   .section.xl-spacing-top.xl-spacing-top-iswa {
     padding-top: 104px;
   }
+
+  .global-footer ul li {
+    line-height: 27px;
+  }
 }
 
 @media screen and (min-width: 1200px) {


### PR DESCRIPTION
**News carousel (bacom-news)**
* Fixed a rare glitch where scrolling quickly to the newsroom carousel could leave both arrows disabled and the carousel stuck
* Arrow state is now driven by a `ResizeObserver` (with a guard against a not-yet-laid-out container) instead of a single `requestAnimationFrame`, so it stays correct once the block settles

**Video marquee (security)**
* Removed the fetched-SVG → `innerHTML` data flow flagged by CodeQL ("DOM text reinterpreted as HTML") on the Stage → Main release
* Inlined the play/pause and mute/unmute icons as static constants (same pattern as `PLAY_SVG`); icons render identically and the block makes 3 fewer network requests

**Header & footer with Target personalization**
* Fixed a case where Adobe Target could reassign `config.mep` and drop our custom `global-navigation` / `global-footer` block overrides on C2 pages
* Re-inject those overrides whenever `mep` is set, so the header and footer load correctly when personalization is active

**Footer spacing**
* Small readability tweak to the line-height of footer link lists

Resolves: [MWPW-204509](https://jira.corp.adobe.com/browse/MWPW-204509)
Resolves: [MWPW-205051](https://jira.corp.adobe.com/browse/MWPW-205051)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.page/resources/iswa-v2/it-starts-with-adobe?martech=off
- After: https://iswa-fixes--da-bacom--adobecom.aem.page/resources/iswa-v2/it-starts-with-adobe?martech=off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
