### PR TITLE
ISWA: Elastic carousel, bento grid & video marquee mobile fixes (MWPW-205739, MWPW-205408, MWPW-205398, MWPW-205645)

### DIFF
--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
@@ -699,7 +699,7 @@ html[dir="rtl"] .elastic-carousel-footer-chevron {
 
 @media (width < 768px) {
   .bacom-elastic-carousel:is(.expand-content, .limited) {
-    margin-inline: 0;
+    margin-inline: var(--grid-margin-width);
 
     .elastic-carousel-container .elastic-carousel-item {
       color: var(--s2a-color-gray-1000);
@@ -735,8 +735,8 @@ html[dir="rtl"] .elastic-carousel-footer-chevron {
   --limited-gap: var(--s2a-spacing-8);
   --limited-content-max-width: 1200px;
   --limited-group-max-width: calc((var(--limited-card-max-width) * var(--limited-visible-slides)) + (var(--limited-gap) * (var(--limited-visible-slides) - 1)));
-  --limited-inset: max(var(--grid-margin-width), calc((100vw - var(--limited-content-max-width)) / 2));
-  --limited-bleed-space: max(0px, calc(100vw - var(--limited-inset) - var(--limited-group-max-width)));
+  --limited-inset: max(var(--grid-margin-width), calc((100% - var(--limited-content-max-width)) / 2));
+  --limited-bleed-space: max(0px, calc(100% - var(--limited-inset) - var(--limited-group-max-width)));
 
   .elastic-carousel-limited-controls {
     display: none;

--- a/blocks/bento-grid/bento-grid.css
+++ b/blocks/bento-grid/bento-grid.css
@@ -236,6 +236,10 @@
   border-radius: 16px;
 }
 
+.bento-grid .grid-item:last-of-type {
+  margin-right: calc(100% - 82vw);
+}
+
 .bento-grid .grid-item-media {
   position: relative;
   border-radius: 16px;

--- a/blocks/bento-grid/bento-grid.css
+++ b/blocks/bento-grid/bento-grid.css
@@ -295,6 +295,7 @@
   justify-content: flex-end;
   gap: 0.5rem;
   margin-top: 1rem;
+  padding-right: calc(100% - 82vw - 24px);
 }
 
 .bento-grid .grid-carousel-arrow {
@@ -397,6 +398,10 @@
 
   .bento-grid .grid-carousel-container {
     padding-left: 0;
+  }
+
+  .bento-grid .grid-carousel-controls {
+    padding-right: 0;
   }
 
   .bento-grid .grid-item {

--- a/blocks/bento-grid/bento-grid.js
+++ b/blocks/bento-grid/bento-grid.js
@@ -476,7 +476,7 @@ function createViewElement(type, config, featuredCells, carouselCells) {
     const row2Config = config[2] || {};
     const allCells = [featuredCell, ...restRow1, ...carouselCells];
     const orderedCells = rotateByStartIndex(allCells, row2Config.startIndex);
-    wrapper.appendChild(buildCarouselRow(orderedCells, { showControls: false }));
+    wrapper.appendChild(buildCarouselRow(orderedCells));
     return wrapper;
   }
 

--- a/blocks/video-marquee/video-marquee.css
+++ b/blocks/video-marquee/video-marquee.css
@@ -208,6 +208,15 @@
   }
 }
 
+@media (max-width: 769px) {
+  .video-marquee .marquee-media .milo-video iframe {
+    aspect-ratio: 9 / 16;
+    width: 100%;
+    height: unset;
+    object-fit: cover;
+  }
+}
+
 @media (min-width: 769px) {
   .video-marquee {
     --marquee-headline-size: 72px;

--- a/test/blocks/bento-grid/bento-grid.test.js
+++ b/test/blocks/bento-grid/bento-grid.test.js
@@ -77,10 +77,10 @@ describe('Bento Grid', () => {
       expect(desktopView.querySelector('.grid-carousel-controls')).to.exist;
     });
 
-    it('combines the featured cell into a single swipeable row on mobile', () => {
+    it('combines the featured cell into a single swipeable row with controls on mobile', () => {
       const mobileView = document.querySelector('.grid-view.view-mobile');
       expect(mobileView.querySelector('.bento-featured')).to.not.exist;
-      expect(mobileView.querySelector('.grid-carousel-controls')).to.not.exist;
+      expect(Boolean(mobileView.querySelector('.grid-carousel-controls'))).to.equal(true);
       const cards = mobileView.querySelectorAll('.grid-carousel .grid-item');
       // all 6 cells (2 in row 1 + 4 in row 2) become carousel cards on mobile
       expect(cards.length).to.equal(6);


### PR DESCRIPTION
**bacom-elastic-carousel**
* Mobile: the `expand-content`/`limited` variants were forcing `margin-inline: 0`, stretching cards edge-to-edge past the page's normal content margin. Now uses `var(--grid-margin-width)` so cards sit inset like the rest of the page.
* Desktop: the `limited` variant's centered 1200px inset (`--limited-inset`/`--limited-bleed-space`) was computed against `100vw`, which includes scrollbar width and doesn't match the containing block. Every other "1200px grid alignment" block (bacom-rich-content, bacom-news, video-marquee) uses `100%`; switched to match, fixing a ~12px left-edge misalignment against the content above the carousel.

**bento-grid**
* Mobile carousel row: the last card had no trailing gutter, sitting flush against the viewport edge — added matching right margin/padding so it's consistent with the other cards.
* Mobile carousel now shows the prev/next controls (previously only shown on desktop).

**video-marquee**
* Fixed AdobeTV video aspect ratio on mobile — iframe now sized `aspect-ratio: 9/16` and fills width instead of using the desktop ratio, so mobile playback isn't cropped/stretched.

Resolves: [MWPW-205739](https://jira.corp.adobe.com/browse/MWPW-205739)
Resolves: [MWPW-205408](https://jira.corp.adobe.com/browse/MWPW-205408)
Resolves: [MWPW-205398](https://jira.corp.adobe.com/browse/MWPW-205398)
Resolves: [MWPW-205645](https://jira.corp.adobe.com/browse/MWPW-205645)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.page/resources/it-starts-with-adobe
- After: https://iswa-fixes--da-bacom--adobecom.aem.page/resources/it-starts-with-adobe

🤖 Generated with [Claude Code](https://claude.com/claude-code)