### PR TITLE
ISWA blocks: add Nala E2E test automation (6 blocks + cross-cutting)

### DIFF
--- a/nala/blocks/ISWA-TEST-PLAN.md
+++ b/nala/blocks/ISWA-TEST-PLAN.md
@@ -1,0 +1,196 @@
+# ISWA Redesign Blocks — Test Plan (6 PRs)
+
+Combined test plan for the six ISWA blocks, all retargeted to the **stage dedicated pages** (`stage--da-bacom--adobecom.aem.live`) after the new AC round (MWPW-2048xx).
+
+| PR | Block | Jira | Nala dir | Automation |
+|----|-------|------|----------|:---------:|
+| [#199](https://github.com/adobecom/da-bacom/pull/199) | video-marquee (net new) | [MWPW-202482](https://jira.corp.adobe.com/browse/MWPW-202482) · [MWPW-204832](https://jira.corp.adobe.com/browse/MWPW-204832) | `nala/blocks/video-marquee/` | ✅ 5 |
+| [#201](https://github.com/adobecom/da-bacom/pull/201) | bacom-elastic-carousel (enh.) | [MWPW-202491](https://jira.corp.adobe.com/browse/MWPW-202491) | `nala/blocks/bacom-elastic-carousel/` | ✅ 5 |
+| [#203](https://github.com/adobecom/da-bacom/pull/203) | bento-grid (enh.) | [MWPW-202490](https://jira.corp.adobe.com/browse/MWPW-202490) | `nala/blocks/bento-grid/` | 8 (7 ✅ + 1 🔴 design-lock) |
+| [#198](https://github.com/adobecom/da-bacom/pull/198) | resource-showcase (net new) | [MWPW-202483](https://jira.corp.adobe.com/browse/MWPW-202483) | `nala/blocks/resource-showcase/` | ✅ 6 |
+| [#202](https://github.com/adobecom/da-bacom/pull/202) | c2-section-metadata (net new) | [MWPW-202513](https://jira.corp.adobe.com/browse/MWPW-202513) | `nala/blocks/c2-section-metadata/` | ✅ 2 |
+| [#205](https://github.com/adobecom/da-bacom/pull/205) | bacom-carousel-c2 (enh.) | [MWPW-202488](https://jira.corp.adobe.com/browse/MWPW-202488) | `nala/blocks/bacom-carousel-c2/` | ✅ 4 |
+| — | ISWA cross-cutting (page-level) | [204904](https://jira.corp.adobe.com/browse/MWPW-204904) · [205058](https://jira.corp.adobe.com/browse/MWPW-205058) · [205025](https://jira.corp.adobe.com/browse/MWPW-205025) · [205271](https://jira.corp.adobe.com/browse/MWPW-205271) | `nala/blocks/iswa-cross-cutting/` | ✅ 4 |
+
+**ISWA cross-cutting** (page-level, runs on the assembled Nala copy of the finished page `/drafts/nala/blocks/resources/it-starts-with-adobe`): `@iswa-footer-not-squished` (footer loads to full height, not the 40px squished state), `@iswa-nav-renders` (standard `global-navigation`), `@iswa-content-alignment` (blocks share a content-column left edge; centered blocks have equal margins), `@iswa-mobile-marquee-full-width` (mobile marquee flush to both edges, no right gutter). The Target/experiment half of 205271 (nav/footer must not revert to C2 when Target is on) needs Target enabled and is left to **manual**.
+
+**Target pages (stage) — dedicated block pages by default, integration page via env:**
+
+| Block | Default (dedicated) | Integration override |
+|-------|---------------------|----------------------|
+| video-marquee | `/drafts/nala/blocks/marquee/marquee-video` | `ISWA_INTEGRATION_PAGE=/drafts/nala/blocks/resources/it-starts-with-adobe?martech=off` points the whole suite at the **ISWA integration page** (authors all five blocks incl. logo + stat eyebrows) |
+| bacom-elastic-carousel | `/drafts/nala/blocks/carousel/elastic-carousel` | 〃 |
+| bento-grid | `/drafts/nala/blocks/bento-grid/bento-grid` | 〃 |
+| resource-showcase | `/drafts/nala/blocks/resource-showcase/resource-showcase` | 〃 |
+| bacom-carousel-c2 | `/drafts/nala/blocks/carousel/carousel-c2` (structure / logo / left-aligned) | 〃 |
+| carousel-c2 stat AC | `/drafts/nala/blocks/resources/it-starts-with-adobe` (the dedicated page authors no stat eyebrow) | 〃 |
+| c2-section-metadata | `/drafts/slavin/iswa/iswa-v2/c2-blocks-parity` | always (metadata is authored page content — the integration page does not author the c2 block) |
+
+Page-object adaptations make both authoring modes pass: marquee's desktop + mobile media rows (9x16 / 16x9 embeds) are filtered to the visible one; the bento section header is found in-block **or** as the text section above the block; the bento featured modal covers both the block-built mp4 modal (dedicated) and the fragment modal (`data-modal-path` → `.dialog-modal`, integration).
+
+**Figma spec:** [ISWA-A-B-Test](https://www.figma.com/design/oiHVkHPgT4vyJzWNULWFyW/ISWA-A-B-Test?node-id=950-1996) (node `950-1996`; c2 also `866-2393`)
+
+---
+
+## 1. Test layers & how to run
+
+### 1.1 Unit tests (shipped in each PR, run offline via web-test-runner)
+
+```bash
+npm run test:file -- "test/blocks/bento-grid/bento-grid.test.js"
+npm run test:file -- "test/blocks/video-marquee/video-marquee.test.js"
+npm run test:file -- "test/blocks/resource-showcase/resource-showcase.test.js"
+```
+> `bacom-elastic-carousel` and `c2-section-metadata` ship no unit tests in their PRs — they are covered by the Nala suites below.
+
+### 1.2 Nala E2E (Playwright against the stage dedicated pages)
+
+Run everything against stage:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
+npx playwright test \
+  nala/blocks/video-marquee nala/blocks/bacom-elastic-carousel \
+  nala/blocks/bento-grid nala/blocks/resource-showcase nala/blocks/c2-section-metadata \
+  nala/blocks/bacom-carousel-c2 \
+  --project=da-bacom-live-chromium
+```
+
+One block / one case:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
+npx playwright test nala/blocks/bento-grid/bento-grid.test.js \
+  --project=da-bacom-live-chromium --grep @bento-grid-video-modal
+```
+
+Run against the combined ISWA integration page instead of the dedicated block pages:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
+  'ISWA_INTEGRATION_PAGE=/drafts/nala/blocks/resources/it-starts-with-adobe?martech=off' \
+npx playwright test nala/blocks/video-marquee nala/blocks/bacom-elastic-carousel \
+  nala/blocks/bento-grid nala/blocks/resource-showcase nala/blocks/c2-section-metadata \
+  nala/blocks/bacom-carousel-c2 \
+  --project=da-bacom-live-chromium
+```
+
+Cross-browser spot checks: swap `--project` for `da-bacom-live-webkit` (Safari) or `da-bacom-live-firefox`.
+
+**Current status:** ✅ verified 2026-08-27 on the dedicated block pages **and** the integration page (via `ISWA_INTEGRATION_PAGE`), across three viewports:
+
+| Project | Result | Reds |
+|---------|--------|------|
+| `da-bacom-live-chromium` (desktop 1440) | **29/30** | bento secondary-bg (design lock, §1.2b) |
+| `da-bacom-live-tablet` (iPad Mini 768) | **29/30** | bento secondary-bg (design lock) |
+| `mobile-chrome-pixel5` (393) | **28/30** | bento secondary-bg (design lock) + **marquee logo distorted on mobile (bug, §5)** |
+
+The earlier card-radius gap is now **fixed on stage** (`@bento-grid-card-radius` green). The suites are viewport-aware: bento/elastic pick the active responsive view per breakpoint (mobile <600, tablet 600–1199, desktop ≥1200).
+
+### 1.2b Bento — Figma-confirmed spec-lock (red until built)
+
+The ISWA Figma (node `950-1996`) shows the secondary "Leadership POV" cards with the **same light-grey rounded-card background** as the featured card. Live has it on **mobile** (grey `246`) but not yet on **desktop** (secondary bg `transparent`), so this test holds the design contract and stays red until the block CSS is updated:
+
+| Requirement (Figma-confirmed) | Encoded by | Live measured state |
+|---|---|---|
+| Secondary cards carry the featured card's light-grey rounded background (desktop + mobile) | `@bento-grid-secondary-bg` | desktop secondary bg `transparent` (featured `rgb(246,246,246)`); mobile ✅ grey |
+
+**Resolved on stage:** `@bento-grid-card-radius` — card corner radius now matches the inner image radius (16px = 16px) ✅.
+
+**Mobile carousel controls — reverted (open question).** The QE AC only says "full carousel on mobile" and the current build renders no mobile arrows; an earlier ad-hoc request asked for controls. Left as "no controls" pending PM/design confirmation (one line to flip in `@bento-grid-responsive` / `@bento-grid-partial-vs-full`).
+
+### 1.3 CI gating (important)
+
+The suites target stage / draft pages. On `main` these pages still render the *old* blocks, so a default PR run against `main` would fail. When wiring these into automated PR runs, gate them the same way the PP suite is gated in
+[nala/utils/pr.run.sh](../utils/pr.run.sh) (tag-based exclusion), or only run them once each block is on `main`. All specs read `LOCAL_TEST_LIVE_URL`, so pointing them elsewhere is a one-line env change.
+
+---
+
+## 2. Automation coverage
+
+| Block | Tag | Validates |
+|-------|-----|-----------|
+| **video-marquee** | `@video-marquee-structure` | left content (eyebrow logo / headline / subcopy) + right video panel render |
+| | `@video-marquee-embed` | AC: adobetv embed configured with autoplay + captions |
+| | `@video-marquee-rounded` | AC (MWPW-204832): video panel has rounded corners that clip its content |
+| | `@video-marquee-logo` | AC (MWPW-204832): eyebrow logo renders (not shrunk) with aspect ratio preserved |
+| | `@video-marquee-full-bleed` | AC (MWPW-204832): large-desktop marquee spans the full browser width (no side gutters) |
+| **elastic-carousel** | `@elastic-carousel-structure` | items with header (logo/headline/expand toggle), media asset, footer |
+| | `@elastic-carousel-expand` | AC: expand icon reveals description **and re-crops the image** (asset height shrinks); collapses again |
+| | `@elastic-carousel-nav` | AC: `>3` cards → controls; Next scrolls the viewport |
+| | `@elastic-carousel-3up` | AC: desktop shows a 3-up view (3 cards across) |
+| | `@elastic-carousel-toggle-placement` | AC: expand toggle sits next to the headline (same row, right of the title) |
+| **bento-grid** | `@bento-grid-structure` | block shell, responsive views, section header, featured video bento, carousel cards |
+| | `@bento-grid-video-modal` | featured click opens modal, plays the mp4, close detaches |
+| | `@bento-grid-carousel-nav` | prev disabled/next enabled; next scrolls + enables prev |
+| | `@bento-grid-responsive` | desktop featured+carousel; mobile single full carousel (no arrows — open question, §1.2b) |
+| | `@bento-grid-play-icon-topright` | AC: play icon in the top-right of the featured + carousel images |
+| | `@bento-grid-partial-vs-full` | AC: desktop partial carousel (overflows, cards < 50% width); mobile full-width single carousel |
+| | `@bento-grid-secondary-bg` | Figma-confirmed req: secondary cards carry the featured card's light-grey background (desktop + mobile) 🔴 desktop pending |
+| | `@bento-grid-card-radius` | Figma-confirmed req: card corner radius matches the inner creative image radius ✅ fixed on stage |
+| **resource-showcase** | `@resource-showcase-structure` | heading; featured image/title/desc/CTA+chevron; secondary list |
+| | `@resource-showcase-featured-link` | featured is a link labelled by its title (aria-label) |
+| | `@resource-showcase-secondary-items` | each secondary item has title + chevron CTA + authored href |
+| | `@resource-showcase-featured-image-top` | AC: image above the body (DOM + geometry); responsive `<picture>` sources |
+| | `@resource-showcase-responsive` | AC: 2-col desktop; stacks to 1 col (featured first) below tablet |
+| | `@resource-showcase-a11y` | AC: one H2 heading; item titles H3; featured img alt; card keyboard-focusable |
+| **c2-section-metadata** | `@c2-section-metadata-style` | style classes applied to owning section (`rounded-corners-bottom` / `wide` / `spacing-md-bottom`) |
+| | `@c2-section-metadata-background` | `has-background` + `.section-background` layer created |
+| **carousel-c2** | `@carousel-c2-structure` | block renders with slides + at least one eyebrow (ingested) |
+| | `@carousel-c2-eyebrow-logo` | AC: a logo image is authored in the eyebrow (`.eyebrow` with an img) |
+| | `@carousel-c2-eyebrow-stat` | AC: a stat is authored in the eyebrow (`.eyebrow.stat` = strong number + `.stat-description`) — on the combined showcase page |
+| | `@carousel-c2-left-aligned` | AC: content components share a left edge + use start/left text-align |
+
+---
+
+## 3. Design parity vs Figma
+
+Compared the live stage render against the ISWA-A-B-Test spec (desktop) and each ticket's
+acceptance criteria. Screenshots captured at 1440px.
+
+| Block | Parity | Notes |
+|-------|:------:|-------|
+| **resource-showcase** | ✅ Strong | Heading, red featured card (image top / title-desc-CTA below), 3 secondary items with chevron CTAs, gradient background — all match the desktop spec. (Gradient is authored via section-metadata, covered by the c2-section-metadata suite on the parity page.) |
+| **bento-grid** | ✅ Good | Play icon **top-right** of every image (measured), **featured video bento** (Watch + click-to-modal), **partial carousel** desktop (overflows) / **full** carousel mobile, card **radius now matches** the inner image. ⚠️ Remaining: desktop secondary-card grey background (§1.2b); verify **section-header alignment** (live centers "Leadership POV"; BASE spec shows it left-aligned). |
+| **elastic-carousel** | ✅ Good | 3-up ✅, expand icon **next to the headline** with **+/−** glyph ✅, click reveals the description **and re-crops the image** (asset `316px → 256px`) ✅, `>3` cards → carousel controls ✅. |
+| **video-marquee** | ✅ Good | Left content (eyebrow logo/headline/subcopy) + right rounded video panel; adobetv iframe player with **autoplay + captions**; full-bleed on large desktop. |
+| **c2-section-metadata** | ➖ N/A visual | Not a visual component — it styles its section. Design parity here means the three c2 blocks it supports (latest-news, footer-cta, footer) match spec `866-2393`; manual/visual review, covered in §4. |
+| **carousel-c2** | ✅ Good | All AC met + asserted: **logo image** authorable in the eyebrow, **stat** authorable in the eyebrow (`strong` "50%" + `.stat-description`), content **left-aligned** (shared left edge, `text-align: start`). |
+
+---
+
+## 4. Manual verification checklist
+
+Automation covers structure + deterministic interactions. Check the rest by hand on the
+stage pages. (The detailed per-interaction template lives in
+[bento-grid/TEST-PLAN.md](bento-grid/TEST-PLAN.md).)
+
+**Cross-cutting**
+- [ ] Real-browser pass on Chrome, Safari, Firefox, Edge + iOS Safari / Android Chrome.
+- [ ] Keyboard: all controls/toggles/arrows focusable and operable (Enter/Space); visible focus.
+- [ ] RTL locale mirrors carousels and inverts arrow direction.
+- [ ] Reduced-motion: videos do not autoplay when `prefers-reduced-motion` is set.
+
+**video-marquee** — [ ] video paints & muted-autoplays in a real browser · [ ] captions (CC) toggle · [ ] player controls reflect state · [ ] logo legibility at small sizes.
+
+**elastic-carousel** — [ ] full-width swipe on mobile · [ ] hover plays the card video · [ ] RTL mirrors arrows.
+
+**bento-grid** — [ ] any card opens the video modal & plays · [ ] closing stops playback · [ ] broken video shows the fallback message · [ ] mobile swipe snaps to center · [ ] section-header alignment vs spec · [ ] desktop secondary grey background once built.
+
+**resource-showcase** — [ ] featured card + each CTA actually navigate to the authored URL · [ ] visible focus ring when tabbing · [ ] WCAG AA contrast on gradient/red card · [ ] iOS Safari + Android Chrome render correctly.
+
+**carousel-c2** — [ ] logo image alt text is meaningful (or intentionally decorative) · [ ] stat + logo eyebrows read correctly across all slides · [ ] left-alignment holds on mobile · [ ] carousel nav/autoplay unaffected by the enhancement.
+
+**c2-section-metadata** — [ ] latest-news / footer-cta / footer render to spec `866-2393` · [ ] background layers show per viewport · [ ] masonry spans / anchor / rounded-corners apply.
+
+---
+
+## 5. Known gaps / risks
+
+- **Marquee logo distorted on mobile (bug to fix)** — the eyebrow logo is hard-sized `168×20` while its asset is `508×120` (4.23:1), i.e. ~2× horizontal stretch. Desktop is only ~4% off (300×30 vs 303×29). Fix: size by one dimension (`height` + `width: auto` or `aspect-ratio`). Caught by `@video-marquee-logo`.
+- **Elastic carousel on mobile stacks vertically** — the current build lays the cards out as a full-width single-column grid (no horizontal swipe, controls hidden). An earlier QE note expected a swipe carousel on mobile; deviation to confirm with design/PM (encoded by `@elastic-carousel-nav`'s mobile branch).
+- Analytics attributes (`daa-*`) not asserted.
+- Card counts / `start-index` rotation are content-driven — suites assert lower bounds, not fixed counts.
+- Visual regression (pixel diffing) is out of scope; parity is by review (§3) + manual (§4).
+- `video-marquee` real-browser playback (headless capture shows black) is left to manual checks.
+- The carousel-c2 stat test and the c2-section-metadata suite target combined/parity pages rather than isolated ones — authored-content ACs have no isolated page.

--- a/nala/blocks/bacom-carousel-c2/bacom-carousel-c2.page.js
+++ b/nala/blocks/bacom-carousel-c2/bacom-carousel-c2.page.js
@@ -1,0 +1,59 @@
+/**
+ * BACOM Carousel C2 Block Page Object
+ *
+ * Covers the carousel-c2 enhancement (MWPW-202488 / PR #205):
+ *  - Author a logo image in the eyebrow of the content (`.eyebrow` containing an img)
+ *  - Author a stat in the eyebrow (`.eyebrow.stat` = <strong>number</strong> + `.stat-description`)
+ *  - All content components remain left aligned (shared left edge, text-align start)
+ *
+ * Slide shape: .carousel-slide > .bacom-rich-content > .foreground > .content
+ *   .content: p.eyebrow (logo) · h3.heading-2 · p.eyebrow.stat · p.action-area
+ */
+export default class CarouselC2 {
+  constructor(page, blockSelector = '.bacom-carousel-c2') {
+    this.page = page;
+    this.block = page.locator(blockSelector);
+    this.slides = this.block.locator('.carousel-slide');
+    this.eyebrows = this.block.locator('.eyebrow');
+
+    // Logo eyebrow (an eyebrow that contains an image)
+    this.logoEyebrow = this.block.locator('.eyebrow:has(img)').first();
+    this.logoEyebrowImg = this.logoEyebrow.locator('img');
+
+    // Stat eyebrow
+    this.statEyebrow = this.block.locator('.eyebrow.stat').first();
+    this.statNumber = this.statEyebrow.locator('strong');
+    this.statDescription = this.statEyebrow.locator('.stat-description');
+  }
+
+  async waitForReady() {
+    await this.block.waitFor({ state: 'attached' });
+    await this.eyebrows.first().waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Left-alignment of the content components inside the slide holding the eyebrows.
+   * Returns whether they share a left edge and all use a start/left text alignment.
+   */
+  async contentAlignment() {
+    return this.block.evaluate((root) => {
+      const stat = root.querySelector('.eyebrow.stat');
+      const content = (stat && stat.closest('.content')) || root.querySelector('.content') || root;
+      const measure = (sel) => {
+        const el = content.querySelector(sel);
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return { sel, left: Math.round(r.x), textAlign: getComputedStyle(el).textAlign };
+      };
+      const parts = ['.eyebrow', 'h1,h2,h3,h4,h5,h6', '.eyebrow.stat', '.action-area']
+        .map(measure)
+        .filter(Boolean);
+      const lefts = parts.map((p) => p.left);
+      return {
+        parts,
+        sharedLeftEdge: lefts.length > 1 ? (Math.max(...lefts) - Math.min(...lefts) < 6) : null,
+        allStartAligned: parts.every((p) => p.textAlign === 'start' || p.textAlign === 'left'),
+      };
+    });
+  }
+}

--- a/nala/blocks/bacom-carousel-c2/bacom-carousel-c2.spec.js
+++ b/nala/blocks/bacom-carousel-c2/bacom-carousel-c2.spec.js
@@ -1,0 +1,42 @@
+// Default targets: the dedicated carousel-c2 page for structure / logo /
+// left-alignment. The dedicated page does not author a stat eyebrow, so the
+// stat AC defaults to the ISWA integration page (which authors both).
+// ISWA_INTEGRATION_PAGE=<path> points the whole suite at the integration page.
+// The block decorates lazily, so the page object waits for the eyebrow first.
+//   LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live
+const INTEGRATION_PAGE = process.env.ISWA_INTEGRATION_PAGE;
+const pagePath = (dedicated) => INTEGRATION_PAGE || dedicated;
+
+module.exports = {
+  name: 'BACOM Carousel C2 Block',
+  features: [
+    {
+      tcid: 'CAROUSEL-C2-01',
+      name: '@carousel-c2-structure',
+      path: pagePath('/drafts/nala/blocks/carousel/carousel-c2?martech=off'),
+      description: 'Ingested carousel-c2 renders with slides and at least one eyebrow.',
+      tags: '@carousel-c2 @bacom @smoke @regression @bacomSmoke',
+    },
+    {
+      tcid: 'CAROUSEL-C2-02',
+      name: '@carousel-c2-eyebrow-logo',
+      path: pagePath('/drafts/nala/blocks/carousel/carousel-c2?martech=off'),
+      description: 'AC: a logo image can be authored in the eyebrow (an .eyebrow with an img).',
+      tags: '@carousel-c2 @bacom @regression',
+    },
+    {
+      tcid: 'CAROUSEL-C2-03',
+      name: '@carousel-c2-eyebrow-stat',
+      path: pagePath('/drafts/nala/blocks/resources/it-starts-with-adobe?martech=off'),
+      description: 'AC: a stat can be authored in the eyebrow (.eyebrow.stat = strong number + .stat-description).',
+      tags: '@carousel-c2 @bacom @regression',
+    },
+    {
+      tcid: 'CAROUSEL-C2-04',
+      name: '@carousel-c2-left-aligned',
+      path: pagePath('/drafts/nala/blocks/carousel/carousel-c2?martech=off'),
+      description: 'AC: all content components are left aligned (shared left edge, text-align start).',
+      tags: '@carousel-c2 @bacom @regression',
+    },
+  ],
+};

--- a/nala/blocks/bacom-carousel-c2/bacom-carousel-c2.test.js
+++ b/nala/blocks/bacom-carousel-c2/bacom-carousel-c2.test.js
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test';
+import { features } from './bacom-carousel-c2.spec.js';
+import CarouselC2 from './bacom-carousel-c2.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+const findFeature = (name) => features.find((f) => f.name === name);
+
+const buildUrl = (baseURL, path) => {
+  if (!miloLibs) return `${baseURL}${path}`;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${baseURL}${path}${sep}${miloLibs.replace(/^[?&]/, '')}`;
+};
+
+test.describe('BACOM Carousel C2 Block Test Suite', () => {
+  test(`${findFeature('@carousel-c2-structure').name} ${findFeature('@carousel-c2-structure').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@carousel-c2-structure');
+    const c2 = new CarouselC2(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await c2.waitForReady();
+    });
+
+    await test.step('Block renders with slides and an eyebrow', async () => {
+      await expect(c2.block).toBeVisible();
+      expect(await c2.slides.count()).toBeGreaterThanOrEqual(1);
+      expect(await c2.eyebrows.count()).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test(`${findFeature('@carousel-c2-eyebrow-logo').name} ${findFeature('@carousel-c2-eyebrow-logo').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@carousel-c2-eyebrow-logo');
+    const c2 = new CarouselC2(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await c2.waitForReady();
+    });
+
+    await test.step('A logo image is authored in the eyebrow (AC)', async () => {
+      await expect(c2.logoEyebrow).toBeVisible();
+      await expect(c2.logoEyebrowImg).toBeAttached();
+      await expect(c2.logoEyebrowImg).toHaveAttribute('src', /.+/);
+    });
+  });
+
+  test(`${findFeature('@carousel-c2-eyebrow-stat').name} ${findFeature('@carousel-c2-eyebrow-stat').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@carousel-c2-eyebrow-stat');
+    const c2 = new CarouselC2(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await c2.waitForReady();
+    });
+
+    await test.step('A stat is authored in the eyebrow (AC)', async () => {
+      await expect(c2.statEyebrow).toBeVisible();
+      await expect(c2.statNumber).not.toBeEmpty();
+      expect((await c2.statNumber.textContent())?.trim()).toMatch(/\d/);
+      await expect(c2.statDescription).not.toBeEmpty();
+    });
+  });
+
+  test(`${findFeature('@carousel-c2-left-aligned').name} ${findFeature('@carousel-c2-left-aligned').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@carousel-c2-left-aligned');
+    const c2 = new CarouselC2(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await c2.waitForReady();
+    });
+
+    await test.step('All content components are left aligned (AC)', async () => {
+      const alignment = await c2.contentAlignment();
+      expect(alignment.parts.length, 'measured multiple components').toBeGreaterThan(1);
+      expect(alignment.allStartAligned, 'components use start/left text-align').toBe(true);
+      expect(alignment.sharedLeftEdge, 'components share a left edge').toBe(true);
+    });
+  });
+});

--- a/nala/blocks/bacom-elastic-carousel/bacom-elastic-carousel.page.js
+++ b/nala/blocks/bacom-elastic-carousel/bacom-elastic-carousel.page.js
@@ -1,0 +1,94 @@
+import { expect } from '@playwright/test';
+
+/**
+ * BACOM Elastic Carousel Block Page Object
+ *
+ * Targets the current `expand-content limited` variant on the dedicated Nala page
+ * (MWPW-202491). DOM:
+ *   .bacom-elastic-carousel
+ *     .elastic-carousel-viewport
+ *       .elastic-carousel-item > .elastic-carousel-item-container
+ *         .elastic-carousel-item-header  (logo img · headline p · .elastic-carousel-expand-toggle [+/-])
+ *         .elastic-carousel-item-media   (.elastic-carousel-expand-content · .elastic-carousel-item-media-asset)
+ *         .elastic-carousel-item-footer  (h3.heading-2 · .elastic-carousel-footer-chevron)
+ *     .elastic-carousel-limited-controls (button.prev / button.next)
+ *
+ * AC covered: 3-up view, expand icon next to the headline, click reveals the
+ * description and re-crops the image, >3 cards → carousel controls.
+ */
+export default class ElasticCarousel {
+  constructor(page, blockSelector = '.bacom-elastic-carousel') {
+    this.page = page;
+    // The dedicated page renders more than one carousel example; use the first
+    // (the `limited` variant with expand toggles + carousel controls).
+    this.block = page.locator(blockSelector).first();
+    this.viewport = this.block.locator('.elastic-carousel-viewport');
+    this.items = this.block.locator('.elastic-carousel-item');
+
+    this.firstItem = this.items.first();
+    this.firstHeader = this.firstItem.locator('.elastic-carousel-item-header');
+    this.firstHeadline = this.firstItem.locator('.elastic-carousel-item-header p').first();
+    this.firstToggle = this.firstItem.locator('.elastic-carousel-expand-toggle');
+    this.firstMedia = this.firstItem.locator('.elastic-carousel-item-media');
+    this.firstAsset = this.firstItem.locator('.elastic-carousel-item-media-asset');
+    this.firstExpandContent = this.firstItem.locator('.elastic-carousel-expand-content');
+    this.firstFooterChevron = this.firstItem.locator('.elastic-carousel-footer-chevron');
+
+    this.controls = this.block.locator('.elastic-carousel-limited-controls');
+    this.prevArrow = this.block.locator('.elastic-carousel-limited-control.prev');
+    this.nextArrow = this.block.locator('.elastic-carousel-limited-control.next');
+  }
+
+  async waitForReady() {
+    await this.block.waitFor({ state: 'attached' });
+    await this.firstToggle.waitFor({ state: 'visible' });
+  }
+
+  /** Cards visible across the viewport (AC: 3-up). */
+  async cardsPerView() {
+    return this.viewport.evaluate((vp) => {
+      const first = vp.querySelector('.elastic-carousel-item');
+      const gap = parseFloat(getComputedStyle(vp).columnGap) || 0;
+      return Math.round(vp.clientWidth / (first.offsetWidth + gap));
+    });
+  }
+
+  /** Expand toggle position relative to the headline (AC: next to the headline). */
+  async togglePlacement() {
+    return this.firstItem.evaluate((item) => {
+      const headline = item.querySelector('.elastic-carousel-item-header p');
+      const toggle = item.querySelector('.elastic-carousel-expand-toggle');
+      if (!headline || !toggle) return null;
+      const h = headline.getBoundingClientRect();
+      const t = toggle.getBoundingClientRect();
+      return {
+        sameRow: Math.abs((h.y + (h.height / 2)) - (t.y + (t.height / 2))) < 24,
+        toggleRightOfHeadline: t.x >= h.x,
+      };
+    });
+  }
+
+  /** Snapshot of expandable content visibility + media-asset height (for re-crop). */
+  async expandState() {
+    return this.firstItem.evaluate((item) => {
+      const content = item.querySelector('.elastic-carousel-expand-content');
+      const asset = item.querySelector('.elastic-carousel-item-media-asset');
+      const visible = !!content && content.getClientRects().length > 0 && content.clientHeight > 0;
+      return { contentVisible: visible, assetHeight: asset ? Math.round(asset.getBoundingClientRect().height) : null };
+    });
+  }
+
+  /** X position of the first card — moves left as the carousel advances. */
+  async firstItemX() {
+    return this.firstItem.evaluate((el) => Math.round(el.getBoundingClientRect().x));
+  }
+
+  /** Advance the carousel; the `limited` variant moves the track (prev becomes enabled). */
+  async clickNext() {
+    const before = await this.firstItemX();
+    await this.nextArrow.click();
+    await expect
+      .poll(async () => this.firstItemX(), { timeout: 5000 })
+      .toBeLessThan(before);
+  }
+}

--- a/nala/blocks/bacom-elastic-carousel/bacom-elastic-carousel.spec.js
+++ b/nala/blocks/bacom-elastic-carousel/bacom-elastic-carousel.spec.js
@@ -1,0 +1,48 @@
+// Default target: the dedicated Nala test page (the current `expand-content
+// limited` variant). Run against the ISWA integration page instead with env
+// ISWA_INTEGRATION_PAGE=<path>.
+//   LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live
+const INTEGRATION_PAGE = process.env.ISWA_INTEGRATION_PAGE;
+const pagePath = (dedicated) => INTEGRATION_PAGE || dedicated;
+
+module.exports = {
+  name: 'BACOM Elastic Carousel Block',
+  features: [
+    {
+      tcid: 'ELASTIC-01',
+      name: '@elastic-carousel-structure',
+      path: pagePath('/drafts/nala/blocks/carousel/elastic-carousel?martech=off'),
+      description: 'Carousel renders items with header (logo/headline/expand toggle), media asset and footer.',
+      tags: '@elastic-carousel @bacom @smoke @regression @bacomSmoke',
+      expected: { minSlides: 3 },
+    },
+    {
+      tcid: 'ELASTIC-02',
+      name: '@elastic-carousel-expand',
+      path: pagePath('/drafts/nala/blocks/carousel/elastic-carousel?martech=off'),
+      description: 'AC: clicking the expand icon reveals the description under the heading and re-crops (shortens) the image; clicking again collapses.',
+      tags: '@elastic-carousel @bacom @regression @a11y',
+    },
+    {
+      tcid: 'ELASTIC-03',
+      name: '@elastic-carousel-nav',
+      path: pagePath('/drafts/nala/blocks/carousel/elastic-carousel?martech=off'),
+      description: 'AC: with more than 3 cards, carousel controls render; Next scrolls the viewport.',
+      tags: '@elastic-carousel @bacom @regression',
+    },
+    {
+      tcid: 'ELASTIC-04',
+      name: '@elastic-carousel-3up',
+      path: pagePath('/drafts/nala/blocks/carousel/elastic-carousel?martech=off'),
+      description: 'AC: desktop shows a 3-up view (three cards across the viewport).',
+      tags: '@elastic-carousel @bacom @regression',
+    },
+    {
+      tcid: 'ELASTIC-05',
+      name: '@elastic-carousel-toggle-placement',
+      path: pagePath('/drafts/nala/blocks/carousel/elastic-carousel?martech=off'),
+      description: 'AC: the expand icon sits next to the headline (same row, to its right).',
+      tags: '@elastic-carousel @bacom @regression',
+    },
+  ],
+};

--- a/nala/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
+++ b/nala/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
@@ -1,0 +1,151 @@
+import { expect, test } from '@playwright/test';
+import { features } from './bacom-elastic-carousel.spec.js';
+import ElasticCarousel from './bacom-elastic-carousel.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+const findFeature = (name) => features.find((f) => f.name === name);
+
+const buildUrl = (baseURL, path) => {
+  if (!miloLibs) return `${baseURL}${path}`;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${baseURL}${path}${sep}${miloLibs.replace(/^[?&]/, '')}`;
+};
+
+test.describe('BACOM Elastic Carousel Block Test Suite', () => {
+  test(`${findFeature('@elastic-carousel-structure').name} ${findFeature('@elastic-carousel-structure').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@elastic-carousel-structure');
+    const carousel = new ElasticCarousel(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await carousel.waitForReady();
+    });
+
+    await test.step('Renders items with header, media and footer', async () => {
+      expect(await carousel.items.count()).toBeGreaterThanOrEqual(feature.expected.minSlides);
+      await expect(carousel.firstHeader).toBeVisible();
+      await expect(carousel.firstAsset).toBeVisible();
+      await expect(carousel.firstToggle).toBeVisible();
+      await expect(carousel.firstFooterChevron).toBeAttached();
+    });
+  });
+
+  test(`${findFeature('@elastic-carousel-expand').name} ${findFeature('@elastic-carousel-expand').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@elastic-carousel-expand');
+    const carousel = new ElasticCarousel(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await carousel.waitForReady();
+    });
+
+    let collapsed;
+    await test.step('Starts collapsed (description hidden, aria-expanded false)', async () => {
+      await expect(carousel.firstToggle).toHaveAttribute('aria-expanded', 'false');
+      collapsed = await carousel.expandState();
+      expect(collapsed.contentVisible).toBe(false);
+    });
+
+    await test.step('Clicking the expand icon reveals the description and re-crops the image (AC)', async () => {
+      await carousel.firstToggle.click();
+      await expect(carousel.firstToggle).toHaveAttribute('aria-expanded', 'true');
+      await expect
+        .poll(async () => (await carousel.expandState()).contentVisible, { timeout: 5000 })
+        .toBe(true);
+      const expanded = await carousel.expandState();
+      expect(expanded.assetHeight, 'image height re-crops (shrinks) to fit the revealed text')
+        .toBeLessThan(collapsed.assetHeight);
+    });
+
+    await test.step('Clicking again collapses', async () => {
+      await carousel.firstToggle.click();
+      await expect(carousel.firstToggle).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  test(`${findFeature('@elastic-carousel-nav').name} ${findFeature('@elastic-carousel-nav').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@elastic-carousel-nav');
+    const carousel = new ElasticCarousel(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await carousel.waitForReady();
+    });
+
+    await test.step('Carousel controls render for >3 cards; Prev disabled at start', async () => {
+      // Below tablet the design is swipe-based: the controls are rendered but
+      // hidden, and nav is by swipe rather than arrows.
+      if ((await page.viewportSize()).width < 768) {
+        await expect(carousel.controls).toBeAttached();
+      } else {
+        await expect(carousel.controls).toBeVisible();
+        await expect(carousel.prevArrow).toBeDisabled();
+        await expect(carousel.nextArrow).toBeEnabled();
+      }
+    });
+
+    if ((await page.viewportSize()).width >= 768) {
+      await test.step('Clicking Next advances the carousel and enables Prev', async () => {
+        await carousel.clickNext();
+        await expect(carousel.prevArrow).toBeEnabled();
+      });
+    } else {
+      await test.step('Mobile: full-width stacked cards, controls hidden', async () => {
+        // Current mobile build stacks the cards vertically at full width
+        // (single-column grid) and hides the arrow controls. NOTE: the earlier
+        // QE note expected a swipe carousel on mobile — deviation to confirm.
+        const layout = await carousel.viewport.evaluate((vp) => {
+          const container = vp.querySelector('.elastic-carousel-container') || vp;
+          const cards = [...container.querySelectorAll('.elastic-carousel-item')];
+          return {
+            count: cards.length,
+            cardWidthPct: cards[0] ? Math.round((100 * cards[0].offsetWidth) / container.clientWidth) : null,
+            stacked: cards.length > 1
+              && cards[1].getBoundingClientRect().top >= cards[0].getBoundingClientRect().bottom - 4,
+          };
+        });
+        expect(layout.count, 'all cards render').toBeGreaterThanOrEqual(3);
+        expect(layout.cardWidthPct, 'cards are full width').toBeGreaterThan(90);
+        expect(layout.stacked, 'cards stack vertically on mobile').toBe(true);
+        await expect(carousel.controls).toBeHidden();
+      });
+    }
+  });
+
+  test(`${findFeature('@elastic-carousel-3up').name} ${findFeature('@elastic-carousel-3up').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@elastic-carousel-3up');
+    const carousel = new ElasticCarousel(page);
+
+    await test.step('Go to test page (desktop)', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await carousel.waitForReady();
+    });
+
+    await test.step('Desktop shows a 3-up view (AC)', async () => {
+      expect(await carousel.cardsPerView()).toBe(3);
+    });
+  });
+
+  test(`${findFeature('@elastic-carousel-toggle-placement').name} ${findFeature('@elastic-carousel-toggle-placement').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@elastic-carousel-toggle-placement');
+    const carousel = new ElasticCarousel(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await carousel.waitForReady();
+    });
+
+    await test.step('Expand icon sits next to the headline (AC)', async () => {
+      const placement = await carousel.togglePlacement();
+      expect(placement, 'toggle + headline measurable').not.toBeNull();
+      expect(placement.sameRow, 'toggle on the same row as the headline').toBe(true);
+      expect(placement.toggleRightOfHeadline, 'toggle to the right of the headline').toBe(true);
+    });
+  });
+});

--- a/nala/blocks/bento-grid/TEST-PLAN.md
+++ b/nala/blocks/bento-grid/TEST-PLAN.md
@@ -1,0 +1,128 @@
+# Bento Grid — Test Plan (Pilot)
+
+**Feature:** Bento Grid enhancement — [MWPW-202490](https://jira.corp.adobe.com/browse/MWPW-202490) / PR [#203](https://github.com/adobecom/da-bacom/pull/203)
+**Repo:** `adobecom/da-bacom` → `nala/blocks/bento-grid/`
+**Suite:** [bento-grid.test.js](bento-grid.test.js) · **Spec:** [bento-grid.spec.js](bento-grid.spec.js) · **Page object:** [bento-grid.page.js](bento-grid.page.js)
+**Live under test:** `https://iswa--da-bacom--adobecom.aem.live/drafts/jsandlan/elastic?martech=off`
+
+---
+
+## 1. Overview
+
+### 1.1 What the PR adds
+
+- Featured **video bento** (eyebrow "Featured video" + description + Watch link).
+- **Play icon** on the top-right of every bento image.
+- **Partial carousel** on desktop/tablet + **full swipeable carousel** on mobile.
+- Click a video card → **video modal** (`#bento-grid-video-modal`) that autoplays the mp4.
+
+### 1.2 Scope
+
+| In scope | Out of scope |
+|----------|--------------|
+| Block shell, responsive views, section header rendering | Exact pixel layout / visual regression |
+| Featured video card structure + play icon + watch link | CDN video streaming reliability |
+| Video modal open/close + source wiring | Milo modal internals |
+| Carousel arrow states + scroll navigation | Analytics (`daa-*`) payload correctness |
+| Mobile-vs-desktop view switching | Full device matrix in every run |
+
+### 1.3 Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| Node.js | v18+ with Playwright installed (`npm ci`) |
+| Network | Reach `*--da-bacom--adobecom.aem.live` and the demo mp4 host |
+| Base URL | Set `LOCAL_TEST_LIVE_URL` to the branch under test |
+
+---
+
+## 2. How to run
+
+### 2.1 Unit tests (shipped with the PR)
+
+```bash
+npm run test:file -- "test/blocks/bento-grid/bento-grid.test.js"
+```
+
+### 2.2 Nala E2E against the ISWA branch
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://iswa--da-bacom--adobecom.aem.live \
+npx playwright test nala/blocks/bento-grid/bento-grid.test.js \
+--project=da-bacom-live-chromium
+```
+
+Run a single case by tag:
+
+```bash
+env LOCAL_TEST_LIVE_URL=https://iswa--da-bacom--adobecom.aem.live \
+npx playwright test nala/blocks/bento-grid/bento-grid.test.js \
+--project=da-bacom-live-chromium --grep @bento-grid-video-modal
+```
+
+> **Note:** the suite targets a **desktop** project (`da-bacom-live-chromium`). The
+> `@bento-grid-responsive` case resizes the viewport itself, so it does not need a
+> separate mobile project. Point `LOCAL_TEST_LIVE_URL` at `stage`/`main` once the
+> block is merged there.
+
+---
+
+## 3. Automated coverage
+
+| TCID | Test (tag) | Validates |
+|------|------------|-----------|
+| BENTO-01 | `@bento-grid-structure` | `con-block`, `role=region`, `aria-label`; mobile/tablet/desktop views all built with only desktop visible; section header heading + subtext; featured card is a `has-video` link with "Featured video" eyebrow, play icon, watch link; ≥4 carousel cards each with play icon + watch link; controls visible |
+| BENTO-02 | `@bento-grid-video-modal` | Clicking the featured card opens `#bento-grid-video-modal`; `<video><source>` src equals the card href; error message hidden; closing (`.dialog-close`) detaches the modal |
+| BENTO-03 | `@bento-grid-carousel-nav` | Prev arrow disabled at start, Next enabled; clicking Next scrolls the container and enables Prev; Prev scrolls back |
+| BENTO-04 | `@bento-grid-responsive` | Desktop shows featured + carousel; resizing to 390px shows the mobile view, hides desktop, keeps carousel cards, and renders **no** arrow controls |
+
+**Status:** ✅ 4/4 passing on `da-bacom-live-chromium` against `iswa` (verified).
+
+---
+
+## 4. Manual verification checklist
+
+Automation covers structure and deterministic interactions. Check the following by hand
+(ideally on the ISWA page above), because they are visual, timing-, or input-dependent.
+
+### 4.1 Visual / layout
+
+- [ ] Featured bento sits left with its "Featured video" eyebrow, heading, description, Watch link.
+- [ ] Play icon renders in the **top-right** of every image and stays there on hover.
+- [ ] Desktop shows a **partial** carousel (next card peeks at the right edge).
+- [ ] Section header (title + subtext) is correctly aligned above the featured card.
+- [ ] No layout shift / overlap at 1280, 1440, and 1920 widths.
+
+### 4.2 Video modal
+
+- [ ] Clicking the featured card and any carousel card opens the modal and the video **plays**.
+- [ ] Closing the modal (X, ESC, click-outside) **stops** playback (no audio keeps playing).
+- [ ] A broken/unavailable video shows "This video is currently unavailable." instead of a blank modal.
+
+### 4.3 Carousel
+
+- [ ] Arrows only appear when there are **more than 3** cards.
+- [ ] Next/Prev move roughly one card at a time; scroll is smooth.
+- [ ] Prev is disabled at the far left, Next is disabled at the far right.
+- [ ] Trackpad / wheel horizontal scroll also updates the arrow disabled states.
+
+### 4.4 Mobile (real device or emulation)
+
+- [ ] Single full-width swipeable carousel; the featured card is folded into it.
+- [ ] No arrow controls on mobile; swipe snaps cards to center.
+- [ ] Tapping a card opens the video modal full-screen-friendly.
+
+### 4.5 Cross-browser / a11y
+
+- [ ] Spot-check Safari (`--project=da-bacom-live-webkit`) and Firefox (`--project=da-bacom-live-firefox`).
+- [ ] Keyboard: cards and arrows are focusable and operable with Enter/Space.
+- [ ] RTL locale mirrors the carousel and inverts arrow directions.
+
+---
+
+## 5. Known gaps / follow-ups
+
+- Analytics attributes (`daa-lh` / `daa-ll`) are not asserted.
+- Exact card count and the `start-index` rotation are content-driven; the suite asserts a
+  lower bound (`minCards`) rather than a fixed number to stay resilient to authoring changes.
+- Visual regression (screenshots) is intentionally left to manual review for the pilot.

--- a/nala/blocks/bento-grid/bento-grid.page.js
+++ b/nala/blocks/bento-grid/bento-grid.page.js
@@ -1,0 +1,260 @@
+import { expect } from '@playwright/test';
+
+/**
+ * Bento Grid Block Page Object
+ *
+ * Covers the enhanced bento-grid block (MWPW-202490 / PR #203):
+ *  - Featured video bento (eyebrow "Featured video" + play icon top-right)
+ *  - Responsive views: single swipeable carousel on mobile, featured + partial
+ *    carousel on tablet/desktop (three .grid-view elements are always rendered,
+ *    CSS shows only the one matching the viewport)
+ *  - Carousel arrow controls (shown only when > 3 cards) with disabled states
+ *  - Click-to-play video modal (#bento-grid-video-modal)
+ *
+ * The block always builds .view-mobile / .view-tablet / .view-desktop; the
+ * desktop-scoped locators below are what a desktop project (da-bacom-live-chromium)
+ * actually sees. Viewport-dependent assertions live in the responsive test, which
+ * resizes the page explicitly.
+ */
+export default class BentoGrid {
+  constructor(page, blockSelector = '.bento-grid') {
+    this.page = page;
+
+    // Block root + decorated shell
+    this.block = page.locator(blockSelector);
+    this.foreground = this.block.locator('.foreground');
+
+    // The three viewport-specific views
+    this.viewMobile = this.block.locator('.grid-view.view-mobile');
+    this.viewTablet = this.block.locator('.grid-view.view-tablet');
+    this.viewDesktop = this.block.locator('.grid-view.view-desktop');
+
+    // Desktop view is the reference view for structural assertions
+    const desktop = this.viewDesktop;
+
+    // Section header
+    this.sectionHeader = desktop.locator('.bento-section-header');
+    this.sectionHeading = desktop.locator('.bento-section-heading');
+    this.sectionSubtext = desktop.locator('.bento-section-subtext');
+
+    // Featured video bento
+    this.featured = desktop.locator('.bento-featured');
+    this.featuredEyebrow = this.featured.locator('.bento-eyebrow');
+    this.featuredHeading = this.featured.locator('.bento-heading');
+    this.featuredPlayIcon = this.featured.locator('.grid-item-play');
+    this.featuredWatchLink = this.featured.locator('.bento-watch-link');
+
+    // Carousel
+    this.carousel = desktop.locator('.grid-carousel');
+    this.carouselContainer = desktop.locator('.grid-carousel-container');
+    this.gridItems = desktop.locator('.grid-carousel .grid-item');
+    this.gridItemPlayIcons = desktop.locator('.grid-carousel .grid-item .grid-item-play');
+    this.gridItemWatchLinks = desktop.locator('.grid-carousel .grid-item .bento-watch-link');
+
+    // Carousel controls
+    this.controls = desktop.locator('.grid-carousel-controls');
+    this.prevArrow = desktop.locator('.grid-carousel-arrow-prev');
+    this.nextArrow = desktop.locator('.grid-carousel-arrow-next');
+
+    // Video modal. Two authoring modes:
+    //  - dedicated pages: block-built mp4 modal (#bento-grid-video-modal)
+    //  - integration page: fragment modal (data-modal-path -> .dialog-modal#<hash>,
+    //    embeds the video as an adobetv iframe), appended to <body>
+    this.modal = page.locator('.dialog-modal, #bento-grid-video-modal, .grid-video-modal');
+    this.modalVideo = this.modal.locator('video, iframe');
+    this.modalError = this.modal.locator('.grid-video-modal-error');
+    this.modalClose = this.modal.locator('.dialog-close');
+
+    // Mobile-view carousel (used by the responsive test)
+    this.mobileGridItems = this.viewMobile.locator('.grid-carousel .grid-item');
+    this.mobileControls = this.viewMobile.locator('.grid-carousel-controls');
+  }
+
+  /**
+   * The responsive view matching the current viewport (block CSS breakpoints:
+   * mobile < 600px, tablet 600–1199px, desktop >= 1200px).
+   */
+  async activeView() {
+    const width = (await this.page.viewportSize())?.width ?? 1440;
+    if (width < 600) return this.viewMobile;
+    if (width < 1200) return this.viewTablet;
+    return this.viewDesktop;
+  }
+
+  /**
+   * Wait until the block has finished decorating (foreground + a rendered view).
+   */
+  async waitForReady() {
+    await this.block.waitFor({ state: 'attached' });
+    await this.foreground.waitFor({ state: 'visible' });
+    const view = await this.activeView();
+    await view.locator('.grid-item').first().waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Section heading + subtext, wherever the page authors them:
+   *  - in-block `.bento-section-header` (dedicated pages), or
+   *  - a text section directly above the block (integration page).
+   */
+  async sectionHeadingInfo() {
+    return this.block.evaluate((root) => {
+      const inBlock = root.querySelector('.bento-section-header');
+      if (inBlock) {
+        return {
+          source: 'in-block',
+          heading: inBlock.querySelector('.bento-section-heading')?.textContent.trim() || '',
+          subtext: inBlock.querySelector('.bento-section-subtext')?.textContent.trim() || '',
+        };
+      }
+      const prev = root.closest('.section')?.previousElementSibling;
+      return {
+        source: 'adjacent-section',
+        heading: prev?.querySelector('h1,h2,h3')?.textContent.trim() || '',
+        subtext: prev?.querySelector('p')?.textContent.trim() || '',
+      };
+    });
+  }
+
+  /**
+   * Source URL of the media playing inside the open modal (native <video>
+   * source on dedicated pages, adobetv iframe src on the integration page).
+   */
+  async modalVideoSource() {
+    return this.modal.evaluate((m) => {
+      const video = m.querySelector('video');
+      if (video) return video.querySelector('source')?.src || video.src || '';
+      return m.querySelector('iframe')?.src || '';
+    });
+  }
+
+  /**
+   * Current horizontal scroll offset of the desktop carousel container.
+   */
+  async getScrollLeft() {
+    return this.carouselContainer.evaluate((el) => el.scrollLeft);
+  }
+
+  /**
+   * Click the Next arrow and wait for the carousel to actually move.
+   */
+  async clickNext() {
+    const before = await this.getScrollLeft();
+    await this.nextArrow.click();
+    await expect
+      .poll(async () => this.getScrollLeft(), { timeout: 5000 })
+      .toBeGreaterThan(before);
+  }
+
+  /**
+   * Click the Prev arrow and wait for the carousel to move back.
+   */
+  async clickPrev() {
+    const before = await this.getScrollLeft();
+    await this.prevArrow.click();
+    await expect
+      .poll(async () => this.getScrollLeft(), { timeout: 5000 })
+      .toBeLessThan(before);
+  }
+
+  /**
+   * Open the video modal: the featured bento on tablet/desktop, the first video
+   * card on mobile (the mobile view has no separate featured card).
+   */
+  async openFeaturedVideo() {
+    const view = await this.activeView();
+    await view.locator('.bento-featured, .grid-item.has-video').first().click();
+    await this.modal.waitFor({ state: 'visible' });
+    await this.modalVideo.waitFor({ state: 'attached' });
+  }
+
+  /**
+   * Close the currently open video modal.
+   */
+  async closeModal() {
+    await this.modalClose.click();
+    await this.modal.waitFor({ state: 'detached' });
+  }
+
+  /**
+   * Placement of a play icon relative to its media box (AC: top-right of the image).
+   * @param {'featured'|'card'} kind
+   */
+  async playIconPlacement(kind) {
+    const sel = kind === 'featured'
+      ? { media: '.view-desktop .bento-featured .bento-featured-media', icon: '.view-desktop .bento-featured .grid-item-play' }
+      : { media: '.view-desktop .grid-carousel .grid-item .grid-item-media', icon: '.view-desktop .grid-carousel .grid-item .grid-item-play' };
+    return this.block.evaluate((root, s) => {
+      const media = root.querySelector(s.media);
+      const icon = root.querySelector(s.icon);
+      if (!media || !icon) return null;
+      const i = icon.getBoundingClientRect();
+      const m = media.getBoundingClientRect();
+      return {
+        inRightHalf: (i.left + (i.width / 2)) > (m.left + (m.width / 2)),
+        inTopHalf: (i.top + (i.height / 2)) < (m.top + (m.height / 2)),
+      };
+    }, sel);
+  }
+
+  /** Desktop carousel geometry (AC: partial carousel that peeks the next card). */
+  async desktopCarouselPartial() {
+    return this.viewDesktop.evaluate((view) => {
+      const container = view.querySelector('.grid-carousel-container');
+      const cards = [...view.querySelectorAll('.grid-carousel .grid-item')];
+      const rightEdge = container.getBoundingClientRect().right;
+      const partialPeek = cards.some((c) => {
+        const r = c.getBoundingClientRect();
+        return r.left < rightEdge - 4 && r.right > rightEdge + 4;
+      });
+      return {
+        overflows: container.scrollWidth > container.clientWidth + 4,
+        partialPeek,
+        cardWidthPct: Math.round((100 * cards[0].offsetWidth) / container.clientWidth),
+      };
+    });
+  }
+
+  /** Mobile carousel geometry (full-width single carousel; now expects arrows too). */
+  async mobileCarouselFull() {
+    return this.viewMobile.evaluate((view) => {
+      const container = view.querySelector('.grid-carousel-container');
+      const cards = [...view.querySelectorAll('.grid-carousel .grid-item')];
+      return {
+        controls: view.querySelectorAll('.grid-carousel-controls').length,
+        cardWidthPct: cards[0] ? Math.round((100 * cards[0].offsetWidth) / container.clientWidth) : null,
+        overflows: container.scrollWidth > container.clientWidth + 4,
+      };
+    });
+  }
+
+  /**
+   * Background + corner-radius audit for the secondary-card enhancement:
+   *  - secondary card background should match the featured card's subtle light grey
+   *  - card corner radius should match the inner creative image's radius
+   */
+  async cardStyleAudit(viewSelector) {
+    return this.block.evaluate((root, viewSel) => {
+      const view = root.querySelector(viewSel) || root;
+      const bg = (el) => (el ? getComputedStyle(el).backgroundColor : null);
+      const radius = (el) => (el ? parseFloat(getComputedStyle(el).borderTopLeftRadius) : null);
+      const isOpaqueGrey = (color) => {
+        const m = color && color.match(/rgba?\(([^)]+)\)/);
+        if (!m) return false;
+        const [r, g, b, a = '1'] = m[1].split(',').map((s) => parseFloat(s));
+        return Number(a) > 0 && Math.abs(r - g) < 8 && Math.abs(g - b) < 8 && r > 205 && r < 252;
+      };
+      const featured = view.querySelector('.bento-featured');
+      const card = view.querySelector('.grid-item');
+      const media = view.querySelector('.grid-item .grid-item-media');
+      return {
+        featuredBg: bg(featured),
+        secondaryBg: bg(card),
+        bgMatchesFeatured: !!featured && !!card && bg(card) === bg(featured),
+        secondaryBgIsGrey: isOpaqueGrey(bg(card)),
+        cardRadius: radius(card),
+        mediaRadius: radius(media),
+        radiusMatchesImage: radius(card) !== null && radius(media) !== null && radius(card) === radius(media),
+      };
+    }, viewSelector);
+  }
+}

--- a/nala/blocks/bento-grid/bento-grid.spec.js
+++ b/nala/blocks/bento-grid/bento-grid.spec.js
@@ -1,0 +1,72 @@
+// Default target: the dedicated Nala test page. Run against the ISWA
+// integration page instead with env ISWA_INTEGRATION_PAGE=<path>.
+//   LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live
+const INTEGRATION_PAGE = process.env.ISWA_INTEGRATION_PAGE;
+const pagePath = (dedicated) => INTEGRATION_PAGE || dedicated;
+
+module.exports = {
+  name: 'BACOM Bento Grid Block',
+  features: [
+    {
+      tcid: 'BENTO-01',
+      name: '@bento-grid-structure',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'Block shell, responsive views, section header, featured video bento and carousel cards render.',
+      tags: '@bento-grid @bacom @smoke @regression @bacomSmoke',
+      expected: {
+        role: 'region',
+        ariaLabel: 'Featured video gallery',
+        minCards: 4,
+      },
+    },
+    {
+      tcid: 'BENTO-02',
+      name: '@bento-grid-video-modal',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'Clicking the featured video opens the video modal, plays the mp4, and closing removes it.',
+      tags: '@bento-grid @bacom @regression',
+    },
+    {
+      tcid: 'BENTO-03',
+      name: '@bento-grid-carousel-nav',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'Prev arrow starts disabled; Next scrolls the carousel and enables Prev.',
+      tags: '@bento-grid @bacom @regression',
+    },
+    {
+      tcid: 'BENTO-04',
+      name: '@bento-grid-responsive',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'Desktop shows featured + carousel; mobile collapses to a single carousel with arrow controls.',
+      tags: '@bento-grid @bacom @regression',
+    },
+    {
+      tcid: 'BENTO-05',
+      name: '@bento-grid-play-icon-topright',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'AC: the video play icon sits in the top-right corner of the featured and carousel bento images.',
+      tags: '@bento-grid @bacom @regression',
+    },
+    {
+      tcid: 'BENTO-06',
+      name: '@bento-grid-partial-vs-full',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'AC: desktop is a partial carousel (overflows, multiple cards visible); mobile is a full-width single carousel with arrow controls.',
+      tags: '@bento-grid @bacom @regression',
+    },
+    {
+      tcid: 'BENTO-07',
+      name: '@bento-grid-secondary-bg',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'Figma-confirmed (red until built): secondary cards carry the featured card light-grey rounded background on desktop and mobile.',
+      tags: '@bento-grid @bacom @regression @iswa-v2',
+    },
+    {
+      tcid: 'BENTO-08',
+      name: '@bento-grid-card-radius',
+      path: pagePath('/drafts/nala/blocks/bento-grid/bento-grid?martech=off'),
+      description: 'Figma-confirmed (red until built): card corner radius matches the radius of the creative image it contains.',
+      tags: '@bento-grid @bacom @regression @iswa-v2',
+    },
+  ],
+};

--- a/nala/blocks/bento-grid/bento-grid.test.js
+++ b/nala/blocks/bento-grid/bento-grid.test.js
@@ -1,0 +1,286 @@
+import { expect, test } from '@playwright/test';
+import { features } from './bento-grid.spec.js';
+import BentoGrid from './bento-grid.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+const findFeature = (name) => features.find((f) => f.name === name);
+
+const buildUrl = (baseURL, path) => {
+  if (!miloLibs) return `${baseURL}${path}`;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${baseURL}${path}${sep}${miloLibs.replace(/^[?&]/, '')}`;
+};
+
+test.describe('BACOM Bento Grid Block Test Suite', () => {
+  test(`${findFeature('@bento-grid-structure').name} ${findFeature('@bento-grid-structure').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-structure');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    await test.step('Block shell has region role and accessible label', async () => {
+      await expect(bento.block).toHaveClass(/con-block/);
+      await expect(bento.block).toHaveAttribute('role', feature.expected.role);
+      await expect(bento.block).toHaveAttribute('aria-label', feature.expected.ariaLabel);
+    });
+
+    await test.step('All three responsive views render; the viewport-appropriate one is visible', async () => {
+      await expect(bento.viewMobile).toBeAttached();
+      await expect(bento.viewTablet).toBeAttached();
+      await expect(bento.viewDesktop).toBeAttached();
+      const view = await bento.activeView();
+      await expect(view).toBeVisible();
+      for (const other of [bento.viewMobile, bento.viewTablet, bento.viewDesktop].filter((v) => v !== view)) {
+        await expect(other).toBeHidden();
+      }
+    });
+
+    await test.step('Section header shows a heading and subtext', async () => {
+      // Header may be authored in-block (dedicated pages) or as the text
+      // section directly above the block (integration page).
+      const header = await bento.sectionHeadingInfo();
+      expect(header.heading, `section heading (${header.source})`).not.toBe('');
+      expect(header.subtext, `section subtext (${header.source})`).not.toBe('');
+    });
+
+    if ((await page.viewportSize()).width >= 600) {
+      await test.step('Featured video bento renders as a clickable video card', async () => {
+        const view = await bento.activeView();
+        const featured = view.locator('.bento-featured');
+        await expect(featured).toBeVisible();
+        await expect(featured).toHaveClass(/has-video/);
+        await expect(featured).toHaveAttribute('href', /.+/);
+        await expect(featured.locator('.bento-heading')).not.toBeEmpty();
+        await expect(featured.locator('.grid-item-play')).toBeVisible();
+        await expect(featured.locator('.bento-watch-link')).toBeVisible();
+      });
+    } else {
+      await test.step('Mobile: the carousel leads with a video card (no separate featured)', async () => {
+        const view = await bento.activeView();
+        const first = view.locator('.grid-item').first();
+        await expect(first).toHaveClass(/has-video/);
+        await expect(first.locator('.bento-heading')).not.toBeEmpty();
+        await expect(first.locator('.grid-item-play')).toBeVisible();
+        await expect(first.locator('.bento-watch-link')).toBeVisible();
+      });
+    }
+
+    await test.step('Carousel renders cards, each with a play icon and watch link', async () => {
+      const view = await bento.activeView();
+      const cardCount = await view.locator('.grid-carousel .grid-item').count();
+      expect(cardCount).toBeGreaterThanOrEqual(feature.expected.minCards);
+      await expect(view.locator('.grid-carousel .grid-item .grid-item-play')).toHaveCount(cardCount);
+      await expect(view.locator('.grid-carousel .grid-item .bento-watch-link')).toHaveCount(cardCount);
+      // Arrow controls are a desktop affordance (mobile is swipe-based per QE AC).
+      if ((await bento.page.viewportSize()).width >= 1200) {
+        await expect(view.locator('.grid-carousel-controls')).toBeVisible();
+      }
+    });
+  });
+
+  test(`${findFeature('@bento-grid-video-modal').name} ${findFeature('@bento-grid-video-modal').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-video-modal');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    await test.step('Clicking the featured video opens the video modal', async () => {
+      await bento.openFeaturedVideo();
+      await expect(bento.modal).toBeVisible();
+      await expect(bento.modalVideo).toBeAttached();
+      await expect(bento.modalError).toBeHidden();
+    });
+
+    await test.step('The modal plays the featured video', async () => {
+      // Dedicated page: native <video><source> mp4. Integration page: the
+      // fragment modal embeds the video as an adobetv iframe.
+      const src = await bento.modalVideoSource();
+      expect(src, 'modal video source (mp4 or embed)').toMatch(/.+/);
+    });
+
+    await test.step('Closing the modal removes it from the page', async () => {
+      await bento.closeModal();
+      await expect(bento.modal).toHaveCount(0);
+    });
+  });
+
+  test(`${findFeature('@bento-grid-carousel-nav').name} ${findFeature('@bento-grid-carousel-nav').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-carousel-nav');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    if ((await page.viewportSize()).width >= 1200) {
+      await test.step('Prev arrow starts disabled, Next arrow is enabled', async () => {
+        await expect(bento.controls).toBeVisible();
+        await expect(bento.prevArrow).toBeDisabled();
+        await expect(bento.nextArrow).toBeEnabled();
+      });
+
+      await test.step('Clicking Next scrolls the carousel and enables Prev', async () => {
+        await bento.clickNext();
+        await expect(bento.prevArrow).toBeEnabled();
+      });
+
+      await test.step('Clicking Prev scrolls back toward the start', async () => {
+        await bento.clickPrev();
+      });
+    } else {
+      await test.step('Below desktop: single swipeable carousel without arrows (QE AC)', async () => {
+        const view = await bento.activeView();
+        const info = await view.evaluate((v) => {
+          const container = v.querySelector('.grid-carousel-container');
+          return { overflows: container.scrollWidth > container.clientWidth + 4 };
+        });
+        expect(info.overflows, 'carousel content overflows (swipeable)').toBe(true);
+      });
+    }
+  });
+
+  test(`${findFeature('@bento-grid-responsive').name} ${findFeature('@bento-grid-responsive').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-responsive');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page (desktop)', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    await test.step('Desktop shows the featured card + carousel controls', async () => {
+      await expect(bento.viewDesktop).toBeVisible();
+      await expect(bento.featured).toBeVisible();
+    });
+
+    await test.step('Mobile collapses to a single carousel with arrow controls', async () => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await expect(bento.viewMobile).toBeVisible();
+      await expect(bento.viewDesktop).toBeHidden();
+      expect(await bento.mobileGridItems.count()).toBeGreaterThan(0);
+      await expect(bento.mobileControls.first()).toBeVisible();
+    });
+  });
+
+  test(`${findFeature('@bento-grid-play-icon-topright').name} ${findFeature('@bento-grid-play-icon-topright').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-play-icon-topright');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page (desktop)', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    await test.step('Featured play icon sits in the top-right of the image (AC)', async () => {
+      const p = await bento.playIconPlacement('featured');
+      expect(p, 'featured icon + media measurable').not.toBeNull();
+      expect(p.inRightHalf, 'featured play icon in right half').toBe(true);
+      expect(p.inTopHalf, 'featured play icon in top half').toBe(true);
+    });
+
+    await test.step('Carousel card play icon sits in the top-right of the image (AC)', async () => {
+      const p = await bento.playIconPlacement('card');
+      expect(p, 'card icon + media measurable').not.toBeNull();
+      expect(p.inRightHalf, 'card play icon in right half').toBe(true);
+      expect(p.inTopHalf, 'card play icon in top half').toBe(true);
+    });
+  });
+
+  test(`${findFeature('@bento-grid-partial-vs-full').name} ${findFeature('@bento-grid-partial-vs-full').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-partial-vs-full');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    await test.step('Desktop is a partial carousel (overflows; multiple cards visible) (AC)', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      const d = await bento.desktopCarouselPartial();
+      expect(d.overflows, 'carousel content overflows the viewport (scrollable)').toBe(true);
+      expect(d.cardWidthPct, 'each card is well under full width (partial — multiple visible)').toBeLessThan(50);
+    });
+
+    await test.step('Mobile is a full-width single carousel with arrow controls', async () => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      const m = await bento.mobileCarouselFull();
+      expect(m.controls, 'mobile carousel exposes arrow controls').toBeGreaterThan(0);
+      expect(m.overflows, 'mobile carousel is swipeable').toBe(true);
+      expect(m.cardWidthPct, 'each mobile card is near full width').toBeGreaterThan(60);
+    });
+  });
+
+  // SKIPPED — bento-grid is not ready yet: the ISWA Figma (node 950-1996) shows the
+  // secondary cards with the same light-grey rounded-card background as the featured
+  // card (mobile already matches; DESKTOP secondary cards are still transparent). The
+  // card RADIUS fix has landed (@bento-grid-card-radius passes). Flip test.skip -> test
+  // once the desktop grey background is implemented.
+  test.skip(`${findFeature('@bento-grid-secondary-bg').name} ${findFeature('@bento-grid-secondary-bg').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-secondary-bg');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page (desktop)', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    await test.step('Desktop: secondary cards match the featured card grey background', async () => {
+      const audit = await bento.cardStyleAudit('.view-desktop');
+      expect(audit.secondaryBgIsGrey, `secondary bg should be light grey, got ${audit.secondaryBg}`).toBe(true);
+      expect(audit.bgMatchesFeatured, `secondary bg ${audit.secondaryBg} should match featured ${audit.featuredBg}`).toBe(true);
+    });
+
+    await test.step('Mobile: the grey background carries through', async () => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      const audit = await bento.cardStyleAudit('.view-mobile');
+      expect(audit.secondaryBgIsGrey, `mobile secondary bg should be light grey, got ${audit.secondaryBg}`).toBe(true);
+    });
+  });
+
+  // SPEC-LOCK (red until built): Figma-confirmed — see note above.
+  test(`${findFeature('@bento-grid-card-radius').name} ${findFeature('@bento-grid-card-radius').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@bento-grid-card-radius');
+    const bento = new BentoGrid(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page (desktop)', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await bento.waitForReady();
+    });
+
+    await test.step('Card corner radius matches the inner creative image radius', async () => {
+      const audit = await bento.cardStyleAudit('.view-desktop');
+      expect(
+        audit.radiusMatchesImage,
+        `card radius ${audit.cardRadius}px should match image radius ${audit.mediaRadius}px`,
+      ).toBe(true);
+    });
+  });
+});

--- a/nala/blocks/c2-section-metadata/c2-section-metadata.page.js
+++ b/nala/blocks/c2-section-metadata/c2-section-metadata.page.js
@@ -1,0 +1,34 @@
+/**
+ * C2 Section Metadata Block Page Object
+ *
+ * Covers the net-new c2-section-metadata block (MWPW-202513 / PR #202).
+ *
+ * This block is not a visual component: it reads authored metadata rows and
+ * applies style classes, a background layer, masonry spans, anchors, etc. to its
+ * parent .section. E2E coverage is therefore intentionally light — it asserts the
+ * structural side effects on the section. Visual fidelity is validated by the
+ * manual checklist / Figma parity review.
+ */
+export default class C2SectionMetadata {
+  constructor(page, blockSelector = '.c2-section-metadata') {
+    this.page = page;
+
+    this.block = page.locator(blockSelector).first();
+    // The section that owns the (first) c2-section-metadata block.
+    this.section = page
+      .locator('.section')
+      .filter({ has: page.locator(blockSelector) })
+      .first();
+    this.background = this.section.locator('.section-background');
+  }
+
+  async waitForReady() {
+    await this.block.waitFor({ state: 'attached' });
+    await this.section.waitFor({ state: 'attached' });
+  }
+
+  /** Class list applied to the owning section. */
+  async sectionClassList() {
+    return this.section.evaluate((el) => [...el.classList]);
+  }
+}

--- a/nala/blocks/c2-section-metadata/c2-section-metadata.page.js
+++ b/nala/blocks/c2-section-metadata/c2-section-metadata.page.js
@@ -1,3 +1,5 @@
+import { expect } from '@playwright/test';
+
 /**
  * C2 Section Metadata Block Page Object
  *
@@ -25,6 +27,14 @@ export default class C2SectionMetadata {
   async waitForReady() {
     await this.block.waitFor({ state: 'attached' });
     await this.section.waitFor({ state: 'attached' });
+    // The owning section decorates lazily (Milo defers below-the-fold sections), so
+    // nudge it into view to trigger decoration and wait for the section-metadata
+    // classes to be applied. CI runners are slow — allow a generous window so the
+    // subsequent assertions don't race the async block decoration.
+    await this.section.scrollIntoViewIfNeeded().catch(() => {});
+    await expect
+      .poll(async () => (await this.sectionClassList()).length, { timeout: 20000 })
+      .toBeGreaterThan(1);
   }
 
   /** Class list applied to the owning section. */

--- a/nala/blocks/c2-section-metadata/c2-section-metadata.page.js
+++ b/nala/blocks/c2-section-metadata/c2-section-metadata.page.js
@@ -27,11 +27,12 @@ export default class C2SectionMetadata {
   async waitForReady() {
     await this.block.waitFor({ state: 'attached' });
     await this.section.waitFor({ state: 'attached' });
-    // The owning section decorates lazily (Milo defers below-the-fold sections), so
-    // nudge it into view to trigger decoration and wait for the section-metadata
-    // classes to be applied. CI runners are slow — allow a generous window so the
-    // subsequent assertions don't race the async block decoration.
-    await this.section.scrollIntoViewIfNeeded().catch(() => {});
+    // The owning section decorates lazily (Milo defers below-the-fold sections).
+    // Trigger it with an in-page, non-blocking scroll (Playwright's
+    // scrollIntoViewIfNeeded can wait the full actionTimeout on some browsers), then
+    // wait for the section-metadata classes to be applied. CI runners are slow, so
+    // allow a generous window so the assertions don't race the async decoration.
+    await this.section.evaluate((el) => el.scrollIntoView()).catch(() => {});
     await expect
       .poll(async () => (await this.sectionClassList()).length, { timeout: 20000 })
       .toBeGreaterThan(1);

--- a/nala/blocks/c2-section-metadata/c2-section-metadata.spec.js
+++ b/nala/blocks/c2-section-metadata/c2-section-metadata.spec.js
@@ -1,0 +1,30 @@
+module.exports = {
+  name: 'BACOM C2 Section Metadata Block',
+  // Section metadata is authored page content, so there is no isolated block
+  // page for it — these assertions run against the c2 parity page, which authors
+  // the style + background metadata under test. Values below reflect the current
+  // c2-blocks-parity authoring; update them if the page changes. Override base
+  // URL at run time with LOCAL_TEST_LIVE_URL.
+  features: [
+    {
+      tcid: 'C2-01',
+      name: '@c2-section-metadata-style',
+      path: '/drafts/slavin/iswa/iswa-v2/c2-blocks-parity?martech=off',
+      description: 'Section-metadata style classes are applied to the owning section.',
+      tags: '@c2-section-metadata @bacom @regression',
+      expected: {
+        // The spacing class is responsive: spacing-md-bottom on desktop,
+        // spacing-xl-bottom on mobile.
+        styleClasses: ['rounded-corners-bottom', 'wide'],
+        spacingPattern: '^spacing-(md|xl)-bottom$',
+      },
+    },
+    {
+      tcid: 'C2-02',
+      name: '@c2-section-metadata-background',
+      path: '/drafts/slavin/iswa/iswa-v2/c2-blocks-parity?martech=off',
+      description: 'Background metadata adds has-background and a .section-background layer.',
+      tags: '@c2-section-metadata @bacom @regression',
+    },
+  ],
+};

--- a/nala/blocks/c2-section-metadata/c2-section-metadata.test.js
+++ b/nala/blocks/c2-section-metadata/c2-section-metadata.test.js
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+import { features } from './c2-section-metadata.spec.js';
+import C2SectionMetadata from './c2-section-metadata.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+const findFeature = (name) => features.find((f) => f.name === name);
+
+const buildUrl = (baseURL, path) => {
+  if (!miloLibs) return `${baseURL}${path}`;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${baseURL}${path}${sep}${miloLibs.replace(/^[?&]/, '')}`;
+};
+
+test.describe('BACOM C2 Section Metadata Block Test Suite', () => {
+  test(`${findFeature('@c2-section-metadata-style').name} ${findFeature('@c2-section-metadata-style').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@c2-section-metadata-style');
+    const c2 = new C2SectionMetadata(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await c2.waitForReady();
+    });
+
+    await test.step('Style classes are applied to the owning section', async () => {
+      // The block applies classes asynchronously after libs load, so poll the
+      // class list until every expected style class is present.
+      await expect
+        .poll(async () => c2.sectionClassList(), { timeout: 5000 })
+        .toEqual(expect.arrayContaining(feature.expected.styleClasses));
+      // Spacing class is responsive (md desktop / xl mobile) — assert the variant.
+      const classes = await c2.sectionClassList();
+      const spacing = new RegExp(feature.expected.spacingPattern);
+      expect(
+        classes.some((c) => spacing.test(c)),
+        `a spacing-* bottom variant is applied, got: ${classes.join(' ')}`,
+      ).toBe(true);
+    });
+  });
+
+  test(`${findFeature('@c2-section-metadata-background').name} ${findFeature('@c2-section-metadata-background').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@c2-section-metadata-background');
+    const c2 = new C2SectionMetadata(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await c2.waitForReady();
+    });
+
+    await test.step('Background metadata adds has-background and a background layer', async () => {
+      await expect(c2.section).toHaveClass(/has-background/);
+      await expect(c2.background.first()).toBeAttached();
+    });
+  });
+});

--- a/nala/blocks/iswa-cross-cutting/iswa-cross-cutting.page.js
+++ b/nala/blocks/iswa-cross-cutting/iswa-cross-cutting.page.js
@@ -1,0 +1,51 @@
+import { expect } from '@playwright/test';
+
+/**
+ * ISWA Cross-cutting Page Object
+ *
+ * Page-level (not block-level) checks that only make sense on the assembled ISWA
+ * page: content-column alignment, footer height, nav, and the mobile marquee gutter.
+ * Covers the cross-cutting fix tickets MWPW-204904 / 205058 / 205025 / (205271 partial).
+ * Target: the Nala copy of the finished page (public on stage), which authors all
+ * five blocks + the real global nav/footer.
+ */
+export default class IswaCrossCutting {
+  constructor(page) {
+    this.page = page;
+    this.marquee = page.locator('.video-marquee').first();
+    this.nav = page.locator('header.global-navigation').first();
+    this.footer = page.locator('footer.global-footer').first();
+    this.footerLink = this.footer.locator('a').first();
+  }
+
+  /** Wait for the blocks + the lazily-loaded global footer to populate. */
+  async waitForReady() {
+    await this.marquee.waitFor({ state: 'attached' });
+    await this.footerLink.waitFor({ state: 'attached', timeout: 20000 });
+    await expect
+      .poll(async () => this.footer.evaluate((el) => Math.round(el.getBoundingClientRect().height)), { timeout: 15000 })
+      .toBeGreaterThan(150);
+  }
+
+  static async height(locator) {
+    return locator.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+  }
+
+  /** Left/right margins of a content wrapper within the viewport. */
+  async margins(selector) {
+    return this.page.evaluate((sel) => {
+      const el = document.querySelector(sel);
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { width: Math.round(r.width), left: Math.round(r.x), right: Math.round(window.innerWidth - r.right) };
+    }, selector);
+  }
+
+  /** Bounding box of the marquee (for the mobile full-width / no-gutter check). */
+  async marqueeBox() {
+    return this.marquee.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return { left: Math.round(r.x), right: Math.round(r.right), width: Math.round(r.width), viewport: window.innerWidth };
+    });
+  }
+}

--- a/nala/blocks/iswa-cross-cutting/iswa-cross-cutting.spec.js
+++ b/nala/blocks/iswa-cross-cutting/iswa-cross-cutting.spec.js
@@ -1,0 +1,39 @@
+// Cross-cutting page-level checks run against the assembled ISWA page — the Nala
+// copy of the finished page (public on stage). Override with ISWA_INTEGRATION_PAGE.
+//   LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live
+const PAGE = process.env.ISWA_INTEGRATION_PAGE
+  || '/drafts/nala/blocks/resources/it-starts-with-adobe?martech=off';
+
+module.exports = {
+  name: 'ISWA Cross-cutting',
+  features: [
+    {
+      tcid: 'CROSS-01',
+      name: '@iswa-footer-not-squished',
+      path: PAGE,
+      description: 'AC (MWPW-205058): the global footer renders at its standard height and is not vertically squished.',
+      tags: '@iswa-cross-cutting @bacom @regression',
+    },
+    {
+      tcid: 'CROSS-02',
+      name: '@iswa-nav-renders',
+      path: PAGE,
+      description: 'AC (MWPW-205271): the standard global navigation renders (not collapsed / not the C2 fallback).',
+      tags: '@iswa-cross-cutting @bacom @regression',
+    },
+    {
+      tcid: 'CROSS-03',
+      name: '@iswa-content-alignment',
+      path: PAGE,
+      description: 'AC (MWPW-204904 / 204890): blocks share a common content-column left edge; centered blocks have equal left/right margins.',
+      tags: '@iswa-cross-cutting @bacom @regression',
+    },
+    {
+      tcid: 'CROSS-04',
+      name: '@iswa-mobile-marquee-full-width',
+      path: PAGE,
+      description: 'AC (MWPW-205025): on mobile the video-marquee spans the full viewport width with no right-side white gutter.',
+      tags: '@iswa-cross-cutting @bacom @regression',
+    },
+  ],
+};

--- a/nala/blocks/iswa-cross-cutting/iswa-cross-cutting.test.js
+++ b/nala/blocks/iswa-cross-cutting/iswa-cross-cutting.test.js
@@ -1,0 +1,97 @@
+import { expect, test } from '@playwright/test';
+import { features } from './iswa-cross-cutting.spec.js';
+import IswaCrossCutting from './iswa-cross-cutting.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+const findFeature = (name) => features.find((f) => f.name === name);
+
+const buildUrl = (baseURL, path) => {
+  if (!miloLibs) return `${baseURL}${path}`;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${baseURL}${path}${sep}${miloLibs.replace(/^[?&]/, '')}`;
+};
+
+test.describe('ISWA Cross-cutting Test Suite', () => {
+  test(`${findFeature('@iswa-footer-not-squished').name} ${findFeature('@iswa-footer-not-squished').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@iswa-footer-not-squished');
+    const iswa = new IswaCrossCutting(page);
+
+    await test.step('Go to the assembled ISWA page', async () => {
+      await page.setViewportSize({ width: 1920, height: 1080 });
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await iswa.waitForReady();
+    });
+
+    await test.step('Global footer renders at a standard (not squished) height (AC)', async () => {
+      const height = await IswaCrossCutting.height(iswa.footer);
+      expect(height, `footer height ${height}px should be a full footer, not squished`).toBeGreaterThan(200);
+    });
+  });
+
+  test(`${findFeature('@iswa-nav-renders').name} ${findFeature('@iswa-nav-renders').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@iswa-nav-renders');
+    const iswa = new IswaCrossCutting(page);
+
+    await test.step('Go to the assembled ISWA page', async () => {
+      await page.setViewportSize({ width: 1920, height: 1080 });
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await iswa.waitForReady();
+    });
+
+    await test.step('Standard global navigation renders (AC)', async () => {
+      await expect(iswa.nav).toBeVisible();
+      const height = await IswaCrossCutting.height(iswa.nav);
+      expect(height, 'nav has a real height').toBeGreaterThan(40);
+    });
+  });
+
+  test(`${findFeature('@iswa-content-alignment').name} ${findFeature('@iswa-content-alignment').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@iswa-content-alignment');
+    const iswa = new IswaCrossCutting(page);
+
+    await test.step('Go to the assembled ISWA page (large desktop)', async () => {
+      await page.setViewportSize({ width: 1920, height: 1080 });
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await iswa.waitForReady();
+    });
+
+    await test.step('Blocks share a common content-column left edge (AC)', async () => {
+      const marquee = await iswa.margins('.video-marquee .marquee-inner');
+      const resource = await iswa.margins('.resource-showcase .resource-showcase-content');
+      const bento = await iswa.margins('.bento-grid .foreground');
+      const lefts = [marquee, resource, bento].filter(Boolean).map((m) => m.left);
+      expect(lefts.length, 'content wrappers measurable').toBeGreaterThan(1);
+      expect(Math.max(...lefts) - Math.min(...lefts), `shared left edge, got lefts ${lefts}`).toBeLessThan(8);
+    });
+
+    await test.step('Centered blocks have equal left/right margins (AC)', async () => {
+      const resource = await iswa.margins('.resource-showcase .resource-showcase-content');
+      const bento = await iswa.margins('.bento-grid .foreground');
+      [resource, bento].filter(Boolean).forEach((m) => {
+        expect(Math.abs(m.left - m.right), `equal margins (left ${m.left} vs right ${m.right})`).toBeLessThan(8);
+      });
+    });
+  });
+
+  test(`${findFeature('@iswa-mobile-marquee-full-width').name} ${findFeature('@iswa-mobile-marquee-full-width').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@iswa-mobile-marquee-full-width');
+    const iswa = new IswaCrossCutting(page);
+
+    await test.step('Go to the assembled ISWA page (mobile)', async () => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await iswa.marquee.waitFor({ state: 'visible' });
+    });
+
+    await test.step('Mobile marquee spans the full viewport width, no right gutter (AC)', async () => {
+      const box = await iswa.marqueeBox();
+      expect(box.left, 'flush to the left edge').toBeLessThanOrEqual(1);
+      expect(box.right, `spans to the right edge (right ${box.right} vs viewport ${box.viewport})`)
+        .toBeGreaterThanOrEqual(box.viewport - 1);
+    });
+  });
+});

--- a/nala/blocks/resource-showcase/resource-showcase.page.js
+++ b/nala/blocks/resource-showcase/resource-showcase.page.js
@@ -1,0 +1,70 @@
+/**
+ * Resource Showcase Block Page Object
+ *
+ * Covers the net-new resource-showcase block (MWPW-202483 / PR #198):
+ *  - Section heading
+ *  - One featured card (image + title + description + text CTA). When the CTA has
+ *    an href the whole card becomes a link with an aria-label and aria-hidden inner
+ *    content.
+ *  - A stacked list of N secondary items, each with title, description and a text
+ *    CTA rendered with a trailing chevron icon.
+ */
+export default class ResourceShowcase {
+  constructor(page, blockSelector = '.resource-showcase') {
+    this.page = page;
+
+    this.block = page.locator(blockSelector);
+    this.heading = this.block.locator('.resource-showcase-heading');
+    this.content = this.block.locator('.resource-showcase-content');
+
+    // Featured card
+    this.featured = this.block.locator('.resource-showcase-featured');
+    this.featuredImage = this.featured.locator('.resource-showcase-featured-image');
+    this.featuredTitle = this.featured.locator('.resource-showcase-featured-title');
+    this.featuredDescription = this.featured.locator('.resource-showcase-featured-description');
+    this.featuredCta = this.featured.locator('.resource-showcase-cta');
+    this.featuredChevron = this.featured.locator('.resource-showcase-cta .resource-showcase-chevron');
+
+    this.featuredBody = this.featured.locator('.resource-showcase-featured-body');
+    this.featuredImg = this.featuredImage.locator('img');
+    this.featuredPictureSources = this.featuredImage.locator('picture source');
+
+    // Secondary list
+    this.list = this.block.locator('.resource-showcase-list');
+    this.items = this.block.locator('.resource-showcase-list .resource-showcase-item');
+    this.itemTitles = this.block.locator('.resource-showcase-item-title');
+    this.itemDescriptions = this.block.locator('.resource-showcase-item .resource-showcase-item-description');
+    this.itemCtas = this.block.locator('.resource-showcase-item .resource-showcase-cta');
+  }
+
+  async waitForReady() {
+    await this.block.waitFor({ state: 'attached' });
+    await this.heading.waitFor({ state: 'visible' });
+    await this.featured.waitFor({ state: 'visible' });
+  }
+
+  /** Bounding boxes for the featured image/body and the featured/list columns. */
+  async layout() {
+    return this.block.evaluate((root) => {
+      const box = (sel) => {
+        const el = root.querySelector(sel);
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return {
+          x: Math.round(r.x), y: Math.round(r.y), w: Math.round(r.width), h: Math.round(r.height), right: Math.round(r.right), bottom: Math.round(r.bottom),
+        };
+      };
+      return {
+        image: box('.resource-showcase-featured .resource-showcase-featured-image'),
+        body: box('.resource-showcase-featured .resource-showcase-featured-body'),
+        featured: box('.resource-showcase-featured'),
+        list: box('.resource-showcase-list'),
+      };
+    });
+  }
+
+  /** Tag name of a locator's first element (e.g. to verify heading levels). */
+  static async tagOf(locator) {
+    return locator.evaluate((el) => el.tagName);
+  }
+}

--- a/nala/blocks/resource-showcase/resource-showcase.spec.js
+++ b/nala/blocks/resource-showcase/resource-showcase.spec.js
@@ -1,0 +1,57 @@
+// Default target: the dedicated Nala test page. Run against the ISWA
+// integration page instead with env ISWA_INTEGRATION_PAGE=<path>.
+//   LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live
+// NOTE: the C2 gradient background (MWPW-204891) is applied via section-metadata,
+// which is not authored on the dedicated page — it is covered by the
+// c2-section-metadata suite / verified on the finished page.
+const INTEGRATION_PAGE = process.env.ISWA_INTEGRATION_PAGE;
+const pagePath = (dedicated) => INTEGRATION_PAGE || dedicated;
+
+module.exports = {
+  name: 'BACOM Resource Showcase Block',
+  features: [
+    {
+      tcid: 'RESOURCE-01',
+      name: '@resource-showcase-structure',
+      path: pagePath('/drafts/nala/blocks/resource-showcase/resource-showcase?martech=off'),
+      description: 'Section heading, featured card (image/title/description/CTA + chevron) and secondary list render.',
+      tags: '@resource-showcase @bacom @smoke @regression @bacomSmoke',
+      expected: { minItems: 1 },
+    },
+    {
+      tcid: 'RESOURCE-02',
+      name: '@resource-showcase-featured-link',
+      path: pagePath('/drafts/nala/blocks/resource-showcase/resource-showcase?martech=off'),
+      description: 'Featured card becomes a single link with an aria-label matching its title.',
+      tags: '@resource-showcase @bacom @regression',
+    },
+    {
+      tcid: 'RESOURCE-03',
+      name: '@resource-showcase-secondary-items',
+      path: pagePath('/drafts/nala/blocks/resource-showcase/resource-showcase?martech=off'),
+      description: 'Every secondary item exposes a title, a chevron CTA and an authored destination href.',
+      tags: '@resource-showcase @bacom @regression',
+    },
+    {
+      tcid: 'RESOURCE-04',
+      name: '@resource-showcase-featured-image-top',
+      path: pagePath('/drafts/nala/blocks/resource-showcase/resource-showcase?martech=off'),
+      description: 'AC: featured image sits above the title/description/CTA body and is served responsively.',
+      tags: '@resource-showcase @bacom @regression',
+    },
+    {
+      tcid: 'RESOURCE-05',
+      name: '@resource-showcase-responsive',
+      path: pagePath('/drafts/nala/blocks/resource-showcase/resource-showcase?martech=off'),
+      description: 'AC: two columns on desktop; stacks to a single column with the featured card first below the tablet breakpoint.',
+      tags: '@resource-showcase @bacom @regression',
+    },
+    {
+      tcid: 'RESOURCE-06',
+      name: '@resource-showcase-a11y',
+      path: pagePath('/drafts/nala/blocks/resource-showcase/resource-showcase?martech=off'),
+      description: 'AC: one section H2 heading, item titles are H3, featured image has alt text, featured card is keyboard-focusable.',
+      tags: '@resource-showcase @bacom @regression @a11y',
+    },
+  ],
+};

--- a/nala/blocks/resource-showcase/resource-showcase.test.js
+++ b/nala/blocks/resource-showcase/resource-showcase.test.js
@@ -1,0 +1,182 @@
+import { expect, test } from '@playwright/test';
+import { features } from './resource-showcase.spec.js';
+import ResourceShowcase from './resource-showcase.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+const findFeature = (name) => features.find((f) => f.name === name);
+
+const buildUrl = (baseURL, path) => {
+  if (!miloLibs) return `${baseURL}${path}`;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${baseURL}${path}${sep}${miloLibs.replace(/^[?&]/, '')}`;
+};
+
+test.describe('BACOM Resource Showcase Block Test Suite', () => {
+  test(`${findFeature('@resource-showcase-structure').name} ${findFeature('@resource-showcase-structure').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@resource-showcase-structure');
+    const resource = new ResourceShowcase(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await resource.waitForReady();
+    });
+
+    await test.step('Section heading renders', async () => {
+      await expect(resource.heading).toBeVisible();
+      await expect(resource.heading).not.toBeEmpty();
+    });
+
+    await test.step('Featured card renders image, title, description and a chevron CTA', async () => {
+      await expect(resource.featured).toBeVisible();
+      await expect(resource.featuredImage).toBeVisible();
+      await expect(resource.featuredTitle).not.toBeEmpty();
+      await expect(resource.featuredCta).toBeVisible();
+      await expect(resource.featuredChevron).toBeAttached();
+    });
+
+    await test.step('Secondary list renders at least one item', async () => {
+      await expect(resource.list).toBeVisible();
+      expect(await resource.items.count()).toBeGreaterThanOrEqual(feature.expected.minItems);
+    });
+  });
+
+  test(`${findFeature('@resource-showcase-featured-link').name} ${findFeature('@resource-showcase-featured-link').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@resource-showcase-featured-link');
+    const resource = new ResourceShowcase(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await resource.waitForReady();
+    });
+
+    await test.step('Featured card is a link labelled by its title', async () => {
+      const tag = await resource.featured.evaluate((el) => el.tagName);
+      expect(tag).toBe('A');
+      await expect(resource.featured).toHaveAttribute('href', /.+/);
+      const title = (await resource.featuredTitle.textContent())?.trim();
+      await expect(resource.featured).toHaveAttribute('aria-label', title);
+    });
+  });
+
+  test(`${findFeature('@resource-showcase-secondary-items').name} ${findFeature('@resource-showcase-secondary-items').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@resource-showcase-secondary-items');
+    const resource = new ResourceShowcase(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await resource.waitForReady();
+    });
+
+    await test.step('Each secondary item has a title, a chevron CTA and an authored href', async () => {
+      const itemCount = await resource.items.count();
+      expect(itemCount).toBeGreaterThan(0);
+      await expect(resource.itemTitles).toHaveCount(itemCount);
+      await expect(resource.itemCtas).toHaveCount(itemCount);
+      const chevrons = resource.block.locator('.resource-showcase-item .resource-showcase-cta .resource-showcase-chevron');
+      await expect(chevrons).toHaveCount(itemCount);
+      const hrefs = await resource.itemCtas.evaluateAll((els) => els.map((e) => e.getAttribute('href')));
+      expect(hrefs).toHaveLength(itemCount);
+      hrefs.forEach((href) => expect(href, 'CTA has an authored destination').toBeTruthy());
+    });
+  });
+
+  test(`${findFeature('@resource-showcase-featured-image-top').name} ${findFeature('@resource-showcase-featured-image-top').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@resource-showcase-featured-image-top');
+    const resource = new ResourceShowcase(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await resource.waitForReady();
+    });
+
+    await test.step('Featured image sits above the title/description/CTA body (AC)', async () => {
+      const imageBeforeBody = await resource.featured.evaluate((el) => {
+        const kids = [...el.children];
+        const img = el.querySelector('.resource-showcase-featured-image');
+        const body = el.querySelector('.resource-showcase-featured-body');
+        return !!(img && body && kids.indexOf(img) < kids.indexOf(body));
+      });
+      expect(imageBeforeBody, 'image before body in DOM order').toBe(true);
+      const lay = await resource.layout();
+      expect(lay.image.y, 'image rendered above body').toBeLessThan(lay.body.y);
+    });
+
+    await test.step('Featured image is served responsively (picture sources)', async () => {
+      await expect(resource.featuredImg).toHaveAttribute('src', /.+/);
+      const srcsets = await resource.featuredPictureSources
+        .evaluateAll((els) => els.map((e) => e.getAttribute('srcset')).filter(Boolean));
+      expect(srcsets.length, 'featured <picture> exposes responsive <source srcset>').toBeGreaterThan(0);
+    });
+  });
+
+  test(`${findFeature('@resource-showcase-responsive').name} ${findFeature('@resource-showcase-responsive').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@resource-showcase-responsive');
+    const resource = new ResourceShowcase(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await resource.waitForReady();
+    });
+
+    await test.step('Desktop: featured and list are side by side', async () => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      const lay = await resource.layout();
+      expect(lay.list.x, 'list column is right of the featured column')
+        .toBeGreaterThan(lay.featured.x + (lay.featured.w / 2));
+    });
+
+    await test.step('Below tablet: single column, featured card first (AC)', async () => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      const lay = await resource.layout();
+      expect(lay.featured.y, 'featured above list').toBeLessThan(lay.list.y);
+      expect(lay.list.y, 'list stacks below featured').toBeGreaterThanOrEqual(lay.featured.bottom - 5);
+      expect(Math.abs(lay.list.x - lay.featured.x), 'shared left edge = one column').toBeLessThan(40);
+    });
+  });
+
+  test(`${findFeature('@resource-showcase-a11y').name} ${findFeature('@resource-showcase-a11y').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@resource-showcase-a11y');
+    const resource = new ResourceShowcase(page);
+    const testPage = buildUrl(baseURL, feature.path);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(testPage);
+      await page.waitForLoadState('domcontentloaded');
+      await resource.waitForReady();
+    });
+
+    await test.step('Exactly one section heading, rendered as H2', async () => {
+      await expect(resource.heading).toHaveCount(1);
+      expect(await ResourceShowcase.tagOf(resource.heading)).toBe('H2');
+    });
+
+    await test.step('Secondary item titles are H3 headings', async () => {
+      const count = await resource.itemTitles.count();
+      expect(count).toBeGreaterThan(0);
+      const tags = await resource.itemTitles.evaluateAll(
+        (els) => [...new Set(els.map((e) => e.tagName))],
+      );
+      expect(tags).toEqual(['H3']);
+    });
+
+    await test.step('Featured image exposes authorable alt text', async () => {
+      await expect(resource.featuredImg).toHaveAttribute('alt', /.*/);
+    });
+
+    await test.step('Featured card is keyboard-focusable', async () => {
+      await resource.featured.focus();
+      await expect(resource.featured).toBeFocused();
+    });
+  });
+});

--- a/nala/blocks/video-marquee/video-marquee.page.js
+++ b/nala/blocks/video-marquee/video-marquee.page.js
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test';
+
+/**
+ * BACOM Video Marquee Block Page Object
+ *
+ * Targets the current version on the dedicated Nala page (MWPW-202482 + fixes
+ * MWPW-204832). The video is embedded as an Adobe TV player iframe (not a native
+ * <video>), so play/pause/mute/CC/volume are provided by that (cross-origin) player;
+ * this suite verifies the embed configuration + layout, and leaves in-player control
+ * interaction to manual/player-API checks.
+ *
+ * DOM: .video-marquee > .marquee-inner
+ *        .marquee-content-row > .marquee-content (.marquee-eyebrow img · h1.marquee-headline · p.marquee-subcopy)
+ *        .marquee-video-row > .marquee-media (rounded, overflow hidden) > .milo-video > iframe (video.tv.adobe.com)
+ */
+export default class VideoMarquee {
+  constructor(page, blockSelector = '.video-marquee') {
+    this.page = page;
+    this.block = page.locator(blockSelector).first();
+    this.eyebrow = this.block.locator('.marquee-eyebrow');
+    this.logoImg = this.block.locator('.marquee-eyebrow img');
+    this.headline = this.block.locator('.marquee-headline');
+    this.subcopy = this.block.locator('.marquee-subcopy').first();
+    // The integration page authors desktop + mobile media rows (and two embeds,
+    // 9x16 portrait + 16x9 landscape); only the breakpoint-appropriate ones show.
+    this.media = this.block.locator('.marquee-media').locator('visible=true').first();
+    this.videoIframe = this.block.locator('.marquee-media iframe').locator('visible=true').first();
+  }
+
+  async waitForReady() {
+    await this.block.waitFor({ state: 'attached' });
+    await this.videoIframe.waitFor({ state: 'attached' });
+  }
+
+  /** Rounded corners + clipping on the video panel (AC: rounded corners). */
+  async mediaStyle() {
+    return this.media.evaluate((el) => {
+      const s = getComputedStyle(el);
+      return { radius: parseFloat(s.borderTopLeftRadius), overflow: s.overflow };
+    });
+  }
+
+  /** Logo render geometry (AC: renders at spec size, not shrunk / distorted). */
+  async logoGeometry() {
+    return this.logoImg.evaluate((img) => {
+      const r = img.getBoundingClientRect();
+      const rendered = r.width / r.height;
+      const natural = img.naturalWidth / img.naturalHeight;
+      return {
+        w: Math.round(r.width),
+        h: Math.round(r.height),
+        // 5% relative tolerance: catches gross distortion, tolerates the
+        // minor hard-sizing drift seen on the integration page (~4%).
+        aspectPreserved: img.naturalWidth > 0
+          ? Math.abs(rendered - natural) / natural < 0.05
+          : null,
+      };
+    });
+  }
+
+  async iframeSrc() {
+    return this.videoIframe.getAttribute('src');
+  }
+
+  /** Block width vs viewport, for the full-bleed background check. */
+  async fullBleed() {
+    return this.block.evaluate((el) => ({
+      blockWidth: Math.round(el.getBoundingClientRect().width),
+      viewportWidth: window.innerWidth,
+    }));
+  }
+}

--- a/nala/blocks/video-marquee/video-marquee.spec.js
+++ b/nala/blocks/video-marquee/video-marquee.spec.js
@@ -1,0 +1,46 @@
+// Default target: the dedicated Nala test page. Run the whole suite against the
+// ISWA integration page instead with env ISWA_INTEGRATION_PAGE=<path>.
+//   LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live
+const INTEGRATION_PAGE = process.env.ISWA_INTEGRATION_PAGE;
+const pagePath = (dedicated) => INTEGRATION_PAGE || dedicated;
+
+module.exports = {
+  name: 'BACOM Video Marquee Block',
+  features: [
+    {
+      tcid: 'MARQUEE-01',
+      name: '@video-marquee-structure',
+      path: pagePath('/drafts/nala/blocks/marquee/marquee-video?martech=off'),
+      description: 'Left content renders eyebrow logo, a headline and subcopy; a right-side video panel renders.',
+      tags: '@video-marquee @bacom @smoke @regression @bacomSmoke',
+    },
+    {
+      tcid: 'MARQUEE-02',
+      name: '@video-marquee-embed',
+      path: pagePath('/drafts/nala/blocks/marquee/marquee-video?martech=off'),
+      description: 'AC: video autoplays and exposes captions — the Adobe TV embed is configured with autoplay + captions.',
+      tags: '@video-marquee @bacom @regression',
+    },
+    {
+      tcid: 'MARQUEE-03',
+      name: '@video-marquee-rounded',
+      path: pagePath('/drafts/nala/blocks/marquee/marquee-video?martech=off'),
+      description: 'AC (MWPW-204832): the video panel renders with rounded corners (and clips its content).',
+      tags: '@video-marquee @bacom @regression',
+    },
+    {
+      tcid: 'MARQUEE-04',
+      name: '@video-marquee-logo',
+      path: pagePath('/drafts/nala/blocks/marquee/marquee-video?martech=off'),
+      description: 'AC (MWPW-204832): the eyebrow logo renders (not shrunk to nothing) with its aspect ratio preserved.',
+      tags: '@video-marquee @bacom @regression',
+    },
+    {
+      tcid: 'MARQUEE-05',
+      name: '@video-marquee-full-bleed',
+      path: pagePath('/drafts/nala/blocks/marquee/marquee-video?martech=off'),
+      description: 'AC (MWPW-204832): on large desktop the marquee spans the full browser width (no white side gutters).',
+      tags: '@video-marquee @bacom @regression',
+    },
+  ],
+};

--- a/nala/blocks/video-marquee/video-marquee.test.js
+++ b/nala/blocks/video-marquee/video-marquee.test.js
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+import { features } from './video-marquee.spec.js';
+import VideoMarquee from './video-marquee.page.js';
+
+const miloLibs = process.env.MILO_LIBS || '';
+const findFeature = (name) => features.find((f) => f.name === name);
+
+const buildUrl = (baseURL, path) => {
+  if (!miloLibs) return `${baseURL}${path}`;
+  const sep = path.includes('?') ? '&' : '?';
+  return `${baseURL}${path}${sep}${miloLibs.replace(/^[?&]/, '')}`;
+};
+
+test.describe('BACOM Video Marquee Block Test Suite', () => {
+  test(`${findFeature('@video-marquee-structure').name} ${findFeature('@video-marquee-structure').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@video-marquee-structure');
+    const marquee = new VideoMarquee(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await marquee.waitForReady();
+    });
+
+    await test.step('Left content (eyebrow logo, headline, subcopy) + right video panel', async () => {
+      await expect(marquee.logoImg).toBeVisible();
+      await expect(marquee.headline).not.toBeEmpty();
+      await expect(marquee.subcopy).toBeVisible();
+      await expect(marquee.media).toBeVisible();
+      await expect(marquee.videoIframe).toBeAttached();
+    });
+  });
+
+  test(`${findFeature('@video-marquee-embed').name} ${findFeature('@video-marquee-embed').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@video-marquee-embed');
+    const marquee = new VideoMarquee(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await marquee.waitForReady();
+    });
+
+    await test.step('Video embed autoplays and exposes captions (AC)', async () => {
+      const src = await marquee.iframeSrc();
+      expect(src, 'Adobe TV video embed').toMatch(/video\.tv\.adobe\.com/);
+      expect(src, 'autoplays on load').toMatch(/autoplay=true/);
+      expect(src, 'captions (CC) enabled').toMatch(/captions=/);
+    });
+  });
+
+  test(`${findFeature('@video-marquee-rounded').name} ${findFeature('@video-marquee-rounded').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@video-marquee-rounded');
+    const marquee = new VideoMarquee(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await marquee.waitForReady();
+    });
+
+    await test.step('Video panel has rounded corners and clips content (AC)', async () => {
+      const style = await marquee.mediaStyle();
+      expect(style.radius, 'rounded corners').toBeGreaterThan(0);
+      expect(style.overflow, 'clips to the rounded panel').not.toBe('visible');
+    });
+  });
+
+  test(`${findFeature('@video-marquee-logo').name} ${findFeature('@video-marquee-logo').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@video-marquee-logo');
+    const marquee = new VideoMarquee(page);
+
+    await test.step('Go to test page', async () => {
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await marquee.waitForReady();
+    });
+
+    await test.step('Eyebrow logo renders at a real size with preserved aspect ratio (AC)', async () => {
+      const logo = await marquee.logoGeometry();
+      expect(logo.w, 'logo not collapsed').toBeGreaterThan(60);
+      expect(logo.h, 'logo not collapsed').toBeGreaterThan(12);
+      expect(logo.aspectPreserved, 'aspect ratio preserved (not distorted)').toBe(true);
+    });
+  });
+
+  test(`${findFeature('@video-marquee-full-bleed').name} ${findFeature('@video-marquee-full-bleed').tags}`, async ({ page, baseURL }) => {
+    const feature = findFeature('@video-marquee-full-bleed');
+    const marquee = new VideoMarquee(page);
+
+    await test.step('Go to test page at large desktop', async () => {
+      await page.setViewportSize({ width: 1920, height: 1080 });
+      await page.goto(buildUrl(baseURL, feature.path));
+      await page.waitForLoadState('domcontentloaded');
+      await marquee.waitForReady();
+    });
+
+    await test.step('Marquee spans the full browser width (no white side gutters) (AC)', async () => {
+      const { blockWidth, viewportWidth } = await marquee.fullBleed();
+      expect(blockWidth, `block ${blockWidth}px should span viewport ${viewportWidth}px`)
+        .toBeGreaterThanOrEqual(viewportWidth - 2);
+    });
+  });
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -66,6 +66,13 @@ const config = {
       },
     },
     {
+      name: `${PROJECT}-live-tablet`,
+      use: {
+        ...devices['iPad Mini'],
+        userAgent: USER_AGENT_DESKTOP,
+      },
+    },
+    {
       name: 'mobile-chrome-pixel5',
       use: {
         ...devices['Pixel 5'],


### PR DESCRIPTION
## Summary(MWPW-205034](https://jira.corp.adobe.com/browse/MWPW-205034)

Test URL:
https://iswa-nala-tests--da-bacom--adobecom.aem.live/drafts/nala/blocks/resources/it-starts-with-adobe

Nala E2E suites + page objects for the six ISWA redesign blocks, plus a page-level **cross-cutting** suite for the assembled page.

| PR | Block / Suite | Jira | Automation |
|----|---------------|------|:---:|
| #199 | video-marquee | MWPW-202482 / 204832 | ✅ 5 |
| #201 | bacom-elastic-carousel | MWPW-202491 | ✅ 5 |
| #203 | bento-grid | MWPW-202490 / 204890 | 7 ✅ + 1 ⏭️ |
| #198 | resource-showcase | MWPW-202483 | ✅ 6 |
| #202 | c2-section-metadata | MWPW-202513 | ✅ 2 |
| #205 | bacom-carousel-c2 | MWPW-202488 | ✅ 4 |
| — | ISWA cross-cutting (page-level) | MWPW-204904 / 205058 / 205025 / 205271 | ✅ 4 |

## How to run
Suites **default to the dedicated block pages** on stage; set `ISWA_INTEGRATION_PAGE` to retarget the whole suite at the combined integration page:

```bash
# dedicated block pages (default) + cross-cutting
env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
npx playwright test nala/blocks/video-marquee nala/blocks/bacom-elastic-carousel \
  nala/blocks/bento-grid nala/blocks/resource-showcase nala/blocks/c2-section-metadata \
  nala/blocks/bacom-carousel-c2 nala/blocks/iswa-cross-cutting \
  --project=da-bacom-live-chromium

# combined integration page
env LOCAL_TEST_LIVE_URL=https://stage--da-bacom--adobecom.aem.live \
  'ISWA_INTEGRATION_PAGE=/drafts/nala/blocks/resources/it-starts-with-adobe?martech=off' \
npx playwright test ... --project=da-bacom-live-chromium
```

## Status
✅ **33 passing + 1 skipped** (34 total) on `da-bacom-live-chromium` — verified on both the dedicated block pages and the integration page.

- **bento-grid** `@bento-grid-secondary-bg` is **skipped** — bento-grid is not ready: the desktop secondary-card grey background (Figma node `950-1996`) isn't built yet (mobile already matches; the card-radius fix has already landed on stage → green). Flip `test.skip` → `test` once it lands.
- **ISWA cross-cutting** (runs on the Nala copy of the finished page): footer renders at full height / not squished (205058), standard `global-navigation` renders (205271), blocks share a content-column left edge + centered blocks have equal margins (204904 / 204890), and the mobile marquee spans full width with no right gutter (205025). The Target-on nav/footer half of 205271 needs Target enabled → **manual**.
- Page objects handle both authoring modes: marquee 9x16 / 16x9 media rows, bento in-block vs adjacent section header, bento mp4 modal (dedicated) vs fragment modal (integration).
- c2-section-metadata stays on the c2 parity page (metadata is authored page content; the integration page doesn't author the c2 block).

## Known issues found during verification
- 🐛 **Marquee mobile logo distorted** (relates to MWPW-204832): on mobile the eyebrow logo is hard-sized to `168×20px` with `object-fit: fill`, stretching the Adobe logo to ~2× its aspect ratio (rendered AR `8.4` vs natural `4.23`). `@video-marquee-logo` catches it (green desktop, red on the mobile project). Fix: `height:auto` / `object-fit:contain` at mobile.
- ⚠️ Flaky unit test `bacom-elastic-carousel › limited › advances and clamps the prev/next disabled state at the ends` — 2000ms mocha timeout under full-suite concurrency; passes 13/13 in isolation. Consider a retry / higher timeout.

Full details in [nala/blocks/ISWA-TEST-PLAN.md](nala/blocks/ISWA-TEST-PLAN.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
