### PR TITLE
ISWA: Bento grid modal hash URLs & elastic carousel header tag (MWPW-204509)

### DIFF
--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.css
@@ -79,13 +79,15 @@ html[dir="rtl"] {
           height: 24px;
         }
 
-        p {
+        p, h1, h2, h3, h4, h5 {
           font-size: 18px;
           font-weight: 800;
           color: var(--s2a-color-gray-1000);
           margin: 0;
           transition: color .1s ease;
           line-height: 22px;
+          letter-spacing: normal;
+          font-family: var(--body-font-family);
         }
       }
 

--- a/blocks/bacom-elastic-carousel/bacom-elastic-carousel.js
+++ b/blocks/bacom-elastic-carousel/bacom-elastic-carousel.js
@@ -214,13 +214,11 @@ const buildSlide = ({ slide, index, slidesTotal }) => {
 
   decorateBlockText(left);
 
-  const headingHTML = heading ? `<p>${heading.innerHTML}</p>` : '';
-
   const content = `
     <div class='elastic-carousel-item-container' id='elastic-carousel-slide-${index + 1}'>
       <div class='elastic-carousel-item-header'>
         ${icon?.outerHTML || ''}
-        ${headingHTML}
+        ${heading?.outerHTML || ''}
       </div>
       <div class='elastic-carousel-item-media'>
         <div class='elastic-carousel-item-media-asset'>${asset.outerHTML}</div>

--- a/blocks/bento-grid/bento-grid.js
+++ b/blocks/bento-grid/bento-grid.js
@@ -231,17 +231,34 @@ async function openFragmentModal(path, hash) {
 }
 
 function attachFragmentTrigger(item, mediaEl, path, hash) {
-  item.href = hash || path;
   item.classList.add('has-video');
   item.dataset.modalPath = path;
-  if (hash) item.dataset.modalHash = hash;
-
   addPlayIcon(mediaEl || item);
 
+  if (hash) {
+    item.href = hash;
+    item.dataset.modalHash = hash;
+    return;
+  }
+
+  item.href = path;
   item.addEventListener('click', (event) => {
     event.preventDefault();
     openFragmentModal(path, hash);
   });
+}
+
+async function setupHashModals(el) {
+  const [{ loadStyle }, modal] = await Promise.all([
+    import(`${LIBS}/utils/utils.js`),
+    import(`${LIBS}/blocks/modal/modal.js`),
+  ]);
+  loadStyle(`${LIBS}/blocks/modal/modal.css`);
+
+  const { hash } = window.location;
+  if (!hash) return;
+  const trigger = el.querySelector(`a[data-modal-hash="${hash}"]`);
+  if (trigger) modal.default(trigger);
 }
 
 function buildTextBlock({ className, eyebrow, heading, description, showWatchLink }) {
@@ -531,6 +548,9 @@ export default function init(el) {
   try {
     el.classList.add('con-block');
     decorateContent(el);
+    if (el.querySelector('a[data-modal-hash]')) {
+      setupHashModals(el).catch((err) => logError('modal setup failed', err));
+    }
   } catch (err) {
     window.lana?.log(`Bento grid Init Error: ${err}`, LANA_OPTIONS);
   }

--- a/test/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
+++ b/test/blocks/bacom-elastic-carousel/bacom-elastic-carousel.test.js
@@ -225,9 +225,9 @@ describe('bacom-elastic-carousel', () => {
   });
 
   describe('headline tag-agnostic header', () => {
-    // Authors changed their pattern and mark the card headline up as an <h3> instead of a <p>.
-    // The header must keep its compact style regardless of the authored tag, so the block
-    // normalizes the headline to a <p> rather than letting decorateBlockText size a heading large.
+    // Authors can mark the card headline up as an <h3> instead of a <p>. The block emits the
+    // authored element as-is (it no longer normalizes it to a <p>); the block CSS keeps the
+    // compact header style across p/h1–h5, so the authored tag must survive into the header.
     const buildSimpleBlock = (count = 3, variantClasses = '') => {
       const slides = Array.from({ length: count }, (_, i) => `
         <div>
@@ -244,14 +244,15 @@ describe('bacom-elastic-carousel', () => {
       return document.querySelector('.bacom-elastic-carousel');
     };
 
-    it('renders the headline as a paragraph even when authored as a heading', async () => {
+    it('preserves the authored heading tag in the header', async () => {
       const el = buildSimpleBlock(3);
       await init(el);
       const header = el.querySelector('.elastic-carousel-item-header');
-      expect(header.querySelector('h1, h2, h3, h4, h5, h6')).to.be.null;
-      const p = header.querySelector('p');
-      expect(p).to.exist;
-      expect(p.textContent).to.contain('Headline 0');
+      const heading = header.querySelector('h3');
+      expect(heading).to.exist;
+      expect(heading.textContent).to.contain('Headline 0');
+      // the authored heading is kept as-is, not downgraded to a <p>
+      expect(Boolean(header.querySelector('p'))).to.equal(false);
     });
 
     it('appends the CTA chevron to a footer link authored as an anchor', async () => {

--- a/test/blocks/bento-grid/bento-grid.test.js
+++ b/test/blocks/bento-grid/bento-grid.test.js
@@ -163,6 +163,33 @@ describe('Bento Grid', () => {
       expect(rachel.tagName).to.equal('A');
       expect(rachel.getAttribute('href')).to.equal('#rachel');
     });
+
+    // The click must fall through to the browser so navigating to the hash updates the URL and
+    // Milo's modal.js (its hashchange listener) opens/closes the dialog — i.e. bento must NOT
+    // preventDefault the way it used to.
+    it('lets the fragment card click drive the URL hash instead of intercepting it', () => {
+      const cards = [...document.querySelectorAll('.grid-view.view-desktop .grid-carousel .grid-item')];
+      const satya = cards.find((c) => c.dataset.modalHash === '#satya');
+      expect(satya).to.exist;
+
+      // defaultPrevented is true here only if the block called preventDefault on the click.
+      let defaultPreventedByBlock;
+      const onDocClick = (e) => {
+        defaultPreventedByBlock = e.defaultPrevented;
+        e.preventDefault(); // stop the test from actually navigating to the hash
+      };
+      document.addEventListener('click', onDocClick, { once: true });
+      satya.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      document.removeEventListener('click', onDocClick);
+
+      expect(defaultPreventedByBlock).to.equal(false);
+    });
+
+    it('does not turn the mp4 featured card into a hash trigger', () => {
+      const featured = document.querySelector('.grid-view.view-desktop .bento-featured');
+      expect(featured.getAttribute('href')).to.contain('.mp4');
+      expect(featured.dataset.modalHash).to.equal(undefined);
+    });
   });
 
   describe('mp4 replaced by Milo video autoblock', () => {


### PR DESCRIPTION
- **Bento grid modals now use Milo's hash-driven flow.** Fragment video cards are wired as real Milo modal triggers (`href="#hash"`, `data-modal-path`, `data-modal-hash`) instead of intercepting the click. Clicking a card now navigates to its hash, so the **hash shows up in the URL** and Milo's `modal.js` owns the whole lifecycle — close button, curtain, Escape, and browser-back all work and strip the hash, matching every other Milo modal. Deep-linking straight to a card's modal via its hash on page load is supported. Raw `.mp4` cards are unchanged (a bare mp4 has no native Milo hash flow).
- **Elastic carousel card header preserves the authored heading tag.** The header now emits the authored element as-is (`<h3>`, etc.) rather than forcing it to a `<p>`; the compact header styling is handled in CSS across `p, h1–h5`.
- **Tests updated** for both blocks to match the new behavior.

Resolves: [MWPW-204509](https://jira.corp.adobe.com/browse/MWPW-204509)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.page/drafts/slavin/iswa/iswa-v2/it-starts-with-adobe-9-4?martech=off
- After: https://iswa-content-qa--da-bacom--adobecom.aem.page/drafts/slavin/iswa/iswa-v2/it-starts-with-adobe-9-4?martech=off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
