### PR TITLE
ISWA: Accessible labels for bento-grid, bacom-news & resource-showcase CTAs (MWPW-204509)

### DIFF
--- a/blocks/bacom-news/bacom-news.js
+++ b/blocks/bacom-news/bacom-news.js
@@ -10,6 +10,13 @@ function isLinkOnlyContent(linkContainer, aTag) {
 
 const isSvgUrl = (url) => /\.svg(\?.*)?$/i.test(url || '');
 
+function splitCtaText(text) {
+  const raw = text || '';
+  const idx = raw.indexOf('|');
+  if (idx === -1) return { visible: raw.trim(), aria: '' };
+  return { visible: raw.slice(0, idx).trim(), aria: raw.slice(idx + 1).trim() };
+}
+
 const MAX_GRID_ITEMS = 3;
 
 const isRtl = () => document.documentElement.getAttribute('dir') === 'rtl';
@@ -104,6 +111,11 @@ export default async function init(el) {
       else if (isLinkOnlyContent(content, linkEl)) {
         content.classList.add('news-item-link');
         linkEl.classList.add('standalone-link', 'label', `${el.classList.contains('quiet') ? 'quiet' : ''}`);
+        const { visible, aria } = splitCtaText(linkEl.textContent);
+        if (aria) {
+          linkEl.textContent = visible;
+          linkEl.setAttribute('aria-label', aria);
+        }
       } else content.classList.add('news-item-body');
     });
   });

--- a/blocks/bento-grid/bento-grid.js
+++ b/blocks/bento-grid/bento-grid.js
@@ -87,6 +87,15 @@ const MP4_RE = /https?:\/\/\S+\.mp4\S*/i;
 
 const isMp4 = (url) => /\.mp4(\?|#|$)/i.test(url || '');
 
+function ctaAriaLabel(node) {
+  if (!node) return '';
+  const authored = node.getAttribute?.('aria-label');
+  if (authored) return authored.trim();
+  const raw = node.textContent || '';
+  const idx = raw.indexOf('|');
+  return idx === -1 ? '' : raw.slice(idx + 1).trim();
+}
+
 function resolveCellVideo(after) {
   const anchors = after.flatMap((node) => [...node.querySelectorAll('a')]);
 
@@ -154,6 +163,7 @@ function extractCells(container) {
       videoSrc: videoSrc || null,
       fragmentPath,
       fragmentHash,
+      ctaLabel: ctaAriaLabel(node),
       eyebrow: eyebrowPara?.textContent.trim() || '',
       heading: heading?.textContent.trim() || '',
       description: descPara?.textContent.trim() || '',
@@ -344,6 +354,7 @@ function buildFeatured(cell) {
 
   const item = document.createElement(cell.videoSrc || cell.fragmentPath ? 'a' : 'div');
   item.className = 'bento-featured';
+  if (cell.ctaLabel) item.setAttribute('aria-label', cell.ctaLabel);
   item.append(text, media);
 
   if (cell.videoSrc) {
@@ -365,6 +376,7 @@ function buildCarouselCard(cell, loadMode) {
 
   const item = document.createElement(cell.videoSrc || cell.fragmentPath ? 'a' : 'div');
   item.className = 'grid-item';
+  if (cell.ctaLabel) item.setAttribute('aria-label', cell.ctaLabel);
   item.appendChild(media);
 
   item.appendChild(buildTextBlock({

--- a/blocks/resource-showcase/resource-showcase.js
+++ b/blocks/resource-showcase/resource-showcase.js
@@ -6,9 +6,21 @@ const CHEVRON_ICON = `<svg class="resource-showcase-chevron" xmlns="http://www.w
   <path d="M2.5 1L7.5 5L2.5 9" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>`;
 
+function splitCtaText(text) {
+  const raw = text || '';
+  const idx = raw.indexOf('|');
+  if (idx === -1) return { visible: raw.trim(), aria: '' };
+  return { visible: raw.slice(0, idx).trim(), aria: raw.slice(idx + 1).trim() };
+}
+
 function decorateCTA(link) {
   if (!link) return null;
   link.classList.add('resource-showcase-cta');
+  const { visible, aria } = splitCtaText(link.textContent);
+  if (aria) {
+    link.textContent = visible;
+    link.setAttribute('aria-label', aria);
+  }
   link.insertAdjacentHTML('beforeend', CHEVRON_ICON);
   return link;
 }
@@ -57,13 +69,14 @@ function buildFeatured(row) {
   featured.className = 'resource-showcase-featured';
   if (href) {
     featured.href = href;
+    const ctaAria = link.getAttribute('aria-label');
     const label = document.createElement('span');
     label.className = link.className;
     label.innerHTML = link.innerHTML;
     link.replaceWith(label);
 
     const title = body.querySelector('.resource-showcase-featured-title');
-    featured.setAttribute('aria-label', title?.textContent.trim() ?? '');
+    featured.setAttribute('aria-label', ctaAria || title?.textContent.trim() || '');
     image.setAttribute('aria-hidden', 'true');
     body.setAttribute('aria-hidden', 'true');
   }

--- a/test/blocks/bacom-news/bacom-news.test.js
+++ b/test/blocks/bacom-news/bacom-news.test.js
@@ -47,6 +47,21 @@ describe('bacom-news', () => {
       expect(el.querySelector('.news-carousel-controls')).to.be.null;
       expect(el.querySelectorAll('.news-item').length).to.equal(3);
     });
+
+    it('splits CTA links: first part visible, second part as aria-label', () => {
+      const links = [...el.querySelectorAll('.news-item .standalone-link')];
+      expect(links.length).to.equal(3);
+      links.forEach((link, i) => {
+        expect(link.textContent.trim()).to.equal('Read story');
+        expect(link.getAttribute('aria-label')).to.equal(`Story ${i}`);
+      });
+    });
+
+    it('leaves the header logo link untouched (CTAs only)', () => {
+      const headerLink = el.querySelector('.news-headline a');
+      expect(headerLink).to.exist;
+      expect(headerLink.getAttribute('aria-label')).to.equal(null);
+    });
   });
 
   describe('carousel mode (> 3 items)', () => {

--- a/test/blocks/bento-grid/bento-grid.test.js
+++ b/test/blocks/bento-grid/bento-grid.test.js
@@ -190,6 +190,19 @@ describe('Bento Grid', () => {
       expect(featured.getAttribute('href')).to.contain('.mp4');
       expect(featured.dataset.modalHash).to.equal(undefined);
     });
+
+    it('sets the card aria-label from the second part of the CTA link text', () => {
+      const featured = document.querySelector('.grid-view.view-desktop .bento-featured');
+      expect(featured.getAttribute('aria-label')).to.equal('Featured');
+
+      const cards = [...document.querySelectorAll('.grid-view.view-desktop .grid-carousel .grid-item')];
+      const satya = cards.find((c) => c.dataset.modalHash === '#satya');
+      expect(satya.getAttribute('aria-label')).to.equal('Watch Satya');
+
+      // rachel's CTA text has no pipe, so no aria-label is added
+      const rachel = cards.find((c) => c.dataset.modalPath === '/fragments/resources/videos/news-rachel');
+      expect(rachel.getAttribute('aria-label')).to.equal(null);
+    });
   });
 
   describe('mp4 replaced by Milo video autoblock', () => {
@@ -219,6 +232,28 @@ describe('Bento Grid', () => {
       expect(card).to.exist;
       expect(card.tagName).to.equal('A');
       expect(card.classList.contains('has-video')).to.be.true;
+    });
+  });
+
+  describe('CTA aria-label after Milo link decoration', () => {
+    // Milo strips " | label" from the CTA text and moves it onto the anchor's aria-label before
+    // this block runs, so bento must read that attribute rather than re-splitting the (now
+    // pipe-less) text.
+    it('copies the Milo-set anchor aria-label onto the card', async () => {
+      document.body.innerHTML = `<div class="bento-grid">
+        <div><div><p>viewport=desktop</p></div></div>
+        <div>
+          <div>
+            <p><picture><img src="./m.png" alt=""></picture></p>
+            <h3>Why brand matters more.</h3>
+            <p>Emily Ketchen, Lenovo CMO.</p>
+            <p><a href="#emily" data-modal-path="/fragments/x/emily" data-modal-hash="#emily" class="modal link-block" aria-label="Watch video of Emily Ketchen's insights">Watch video</a></p>
+          </div>
+        </div>
+      </div>`;
+      await init(document.querySelector('.bento-grid'));
+      const featured = document.querySelector('.grid-view.view-desktop .bento-featured');
+      expect(featured.getAttribute('aria-label')).to.equal("Watch video of Emily Ketchen's insights");
     });
   });
 

--- a/test/blocks/resource-showcase/resource-showcase.test.js
+++ b/test/blocks/resource-showcase/resource-showcase.test.js
@@ -103,4 +103,43 @@ describe('Resource Showcase', () => {
 
     expect(document.querySelector('.resource-showcase-content')).to.not.exist;
   });
+
+  it('splits secondary CTA links: first part visible, second part as aria-label', async () => {
+    document.body.innerHTML = `<div class="resource-showcase">
+      <div><div><p>Heading</p></div></div>
+      <div>
+        <div><h3>Featured</h3><p>Desc.</p></div>
+        <div><p><a href="https://example.com/a">Start assessment | Start assessment for AI maturity index</a></p></div>
+      </div>
+      <div>
+        <div><h3>Secondary</h3><p>Desc.</p></div>
+        <div><p><a href="https://example.com/b">Explore insights | Explore insights and digital trends research</a></p></div>
+      </div>
+    </div>`;
+
+    await init(document.querySelector('.resource-showcase'));
+
+    const cta = document.querySelector('.resource-showcase-item .resource-showcase-cta');
+    expect(cta.localName).to.equal('a');
+    expect(cta.getAttribute('aria-label')).to.equal('Explore insights and digital trends research');
+    expect(cta.textContent.trim()).to.equal('Explore insights');
+  });
+
+  it('uses the featured CTA second part as the card aria-label', async () => {
+    document.body.innerHTML = `<div class="resource-showcase">
+      <div><div><p>Heading</p></div></div>
+      <div>
+        <div><h3>Find your path.</h3><p>Desc.</p></div>
+        <div><p><a href="https://example.com/a">Start assessment | Start assessment for AI maturity index</a></p></div>
+      </div>
+    </div>`;
+
+    await init(document.querySelector('.resource-showcase'));
+
+    const featured = document.querySelector('.resource-showcase-featured');
+    expect(featured.localName).to.equal('a');
+    expect(featured.getAttribute('aria-label')).to.equal('Start assessment for AI maturity index');
+    const span = featured.querySelector('span.resource-showcase-cta');
+    expect(span.textContent.trim()).to.equal('Start assessment');
+  });
 });


### PR DESCRIPTION
Adds accessible labels (`aria-label`) to CTA links across three blocks, sourced from the authored `Visible label | Accessible label` pattern (the text after the first pipe becomes the accessible name).

- **bento-grid** — the card `<a>` now carries the CTA's accessible label. It reads the anchor's `aria-label` (which Milo's link decoration sets from the pipe *before* the block runs, stripping it from the text), falling back to splitting the raw text for links Milo skips or in tests. This is the fix for cards previously rendering with no `aria-label`.
- **bacom-news** — the "Learn more" CTAs split into a visible first part + `aria-label` second part. The header/logo link is intentionally left untouched.
- **resource-showcase** — CTAs split the same way; the featured card's `aria-label` uses the CTA's accessible label, falling back to the heading when the CTA has no label.

Note: the small pipe-splitting helper is duplicated per block (each block is self-contained and imports only Milo utils); kept local rather than introducing a shared module.

Resolves: [MWPW-204509](https://jira.corp.adobe.com/browse/MWPW-204509)

<!-- Publish your page for a lighthouse score before submitting a PR. -->
**Test URLs:**
- Before: https://stage--da-bacom--adobecom.aem.page/drafts/slavin/iswa/iswa-v2/it-starts-with-adobe-9-4?martech=off
- After: https://iswa-a11y--da-bacom--adobecom.aem.page/drafts/slavin/iswa/iswa-v2/it-starts-with-adobe-9-4?martech=off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
